### PR TITLE
Fix to COOK-1136 to set the correct permissions on the runit_service named pipes

### DIFF
--- a/templates/sv-down.erb
+++ b/templates/sv-down.erb
@@ -1,1 +1,0 @@
-sv-down.erb


### PR DESCRIPTION
JIRA issue: http://tickets.opscode.com/browse/COOK-1136

This change waits until the named pipes are created and then sets the ownership on them to correctly reflect the ownership of the runit_service
