### PR TITLE
[COOK-1960] Remove redunant log-run template block

### DIFF
--- a/definitions/runit_service.rb
+++ b/definitions/runit_service.rb
@@ -91,17 +91,6 @@ EOF
     end
   end
 
-  template "#{sv_dir_name}/log/run" do
-    owner params[:owner]
-    group params[:group]
-    mode 0755
-    source "sv-#{params[:log_template_name]}-log-run.erb"
-    cookbook params[:cookbook] if params[:cookbook]
-    if params[:options].respond_to?(:has_key?)
-      variables :options => params[:options]
-    end
-  end
-
   unless params[:env].empty?
     directory "#{sv_dir_name}/env" do
       mode 0755


### PR DESCRIPTION
The removed lines are a duplicate of the block at [L93](https://github.com/opscode-cookbooks/runit/blob/master/definitions/runit_service.rb#L93) except having
it repeat outside the if default_logger statement causes the run to fail
when you don't have an sv-server-log-run template. I think that defeats
the purpose of having a default_logger param.
