### PR TITLE
Fix supervise permissions bug from COOK-1136 merge

### DIFF
--- a/definitions/runit_service.rb
+++ b/definitions/runit_service.rb
@@ -185,11 +185,13 @@ EOF
     block do
       Chef::Log.debug("Setting ownership on named pipes in '#{sv_dir_name}/supervise/'...")
       ::Dir.glob("#{sv_dir_name}/supervise/*").each do | supervise_file |
+        current_file_resource = Chef::Resource::File.new(supervise_file)
+
         file_resource = Chef::Resource::File.new(supervise_file)
         file_resource.owner(params[:owner])
         file_resource.group(params[:group])
 
-        access_control = Chef::FileAccessControl.new(file_resource, file_resource.path)
+        access_control = Chef::FileAccessControl.new(current_file_resource, file_resource, file_resource.path)
         Chef::Log.debug("Setting ownership for named pipe '#{supervise_file}' to #{file_resource.owner}:#{file_resource.group}...")
         access_control.set_all
       end


### PR DESCRIPTION
Chef::FileAccessControl.new requires 3 parameters and previously was
only being passed two. This seems to fix and works it but I'm not 100%
confident it's the correct solution.
