### PR TITLE
remote trailing comma in recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ execute "start-runsvdir" do
   command value_for_platform(
     "debian" => { "default" => "runsvdir-start" },
     "ubuntu" => { "default" => "start runsvdir" },
-    "gentoo" => { "default" => "/etc/init.d/runit-start start" },
+    "gentoo" => { "default" => "/etc/init.d/runit-start start" }
   )
   action :nothing
 end


### PR DESCRIPTION
knife test on ruby 1.8.7 was returning
FATAL: Cookbook file recipes/default.rb has a ruby syntax error:
FATAL: /runit/recipes/default.rb:29: syntax error, unexpected ')'
FATAL: /runit/recipes/default.rb:42: syntax error, unexpected kDO_BLOCK, expecting kEND
FATAL:   packages.each do |p|
FATAL:                   ^
FATAL: /runit/recipes/default.rb:43: syntax error, unexpected tIDENTIFIER, expecting kDO or '{' or '('

removed trailing comma in default.rb
