### PR TITLE
Syntax Errors from extra comma

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ execute "start-runsvdir" do
   command value_for_platform(
     "debian" => { "default" => "runsvdir-start" },
     "ubuntu" => { "default" => "start runsvdir" },
-    "gentoo" => { "default" => "/etc/init.d/runit-start start" },
+    "gentoo" => { "default" => "/etc/init.d/runit-start start" }
   )
   action :nothing
 end


### PR DESCRIPTION
I removed the extra comma that caused a few errors on startup with nginx::source.
