### PR TITLE
Add support for wheezy/sid

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -92,7 +92,7 @@ when "debian","gentoo"
       "gentoo" => { "default" => :run }
     ), "execute[start-runsvdir]", :immediately
     notifies value_for_platform(
-      "debian" => { "squeeze/sid" => :run, "default" => :nothing },
+      "debian" => { "squeeze/sid" => :run, "wheezy/sid" => :run, "default" => :nothing },
       "default" => :nothing
     ), "execute[runit-hup-init]", :immediately
   end


### PR DESCRIPTION
fix "FATAL: NameError: Cannot find a resource for runit_service on debian version wheezy/sid"
