### PR TITLE
Fix options variable name at debian init.d template

### DIFF
--- a/templates/debian/init.d.erb
+++ b/templates/debian/init.d.erb
@@ -1,18 +1,18 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:          <%= @params[:name] %>
+# Provides:          <%= @options[:name] %>
 # Required-Start:
 # Required-Stop:
 # Default-Start:
 # Default-Stop:
-# Short-Description: initscript for runit-managed <%= @params[:name] %> service
+# Short-Description: initscript for runit-managed <%= @options[:name] %> service
 ### END INIT INFO
 
 # Author: Opscode, Inc. <cookbooks@opscode.com>
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="runit-managed <%= @params[:name] %>"
-NAME=<%= @params[:name] %>
+DESC="runit-managed <%= @options[:name] %>"
+NAME=<%= @options[:name] %>
 RUNIT=/usr/bin/sv
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -30,16 +30,16 @@ SCRIPTNAME=/etc/init.d/$NAME
 case "$1" in
   start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
-        $RUNIT <%= @params[:start_command] %> $NAME
+        $RUNIT <%= @options[:start_command] %> $NAME
         [ "$VERBOSE" != no ] && log_end_msg $?
         ;;
   stop)
         [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-        $RUNIT <%= @params[:stop_command] %> $NAME
+        $RUNIT <%= @options[:stop_command] %> $NAME
         [ "$VERBOSE" != no ] && log_end_msg $?
         ;;
   status)
-        $RUNIT <%= @params[:status_command] %> $NAME && exit 0 || exit $?
+        $RUNIT <%= @options[:status_command] %> $NAME && exit 0 || exit $?
         ;;
   reload)
         [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
@@ -53,7 +53,7 @@ case "$1" in
         ;;
   restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
-        $RUNIT <%= @params[:restart_command] %> $NAME
+        $RUNIT <%= @options[:restart_command] %> $NAME
         [ "$VERBOSE" != no ] && log_end_msg $?
         ;;
   *)


### PR DESCRIPTION
Here: https://github.com/opscode-cookbooks/runit/blob/master/libraries/provider_runit_service.rb#L393 passed `options`, but init.d debian template is used `params` variable.

Fixed inconsistency at template
