### PR TITLE
it should create the runit-start template before calling it

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -77,6 +77,13 @@ when "rhel"
 
 when "debian","gentoo"
 
+  if platform?("gentoo")
+    template "/etc/init.d/runit-start" do
+      source "runit-start.sh.erb"
+      mode 0755
+    end
+  end
+
   package "runit" do
     action :install
     if platform?("ubuntu", "debian")
@@ -103,12 +110,6 @@ when "debian","gentoo"
       mode 0644
       notifies :run, "execute[start-runsvdir]", :immediately
       only_if do ::File.directory?("/etc/event.d") end
-    end
-  end
-  if platform?("gentoo")
-    template "/etc/init.d/runit-start" do
-      source "runit-start.sh.erb"
-      mode 0755
     end
   end
 end


### PR DESCRIPTION
I saw that it was like this before : 

https://github.com/opscode-cookbooks/runit/blob/1ee0a783ae1b2a9b1966323c4377eede079d8e28/recipes/default.rb
