### PR TITLE
COOK-2549 service_dir on gentoo should be /var/service 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,7 +66,7 @@ when "gentoo"
 
   default["runit"]["sv_bin"] = "/usr/bin/sv"
   default["runit"]["chpst_bin"] = "/usr/bin/chpst"
-  default["runit"]["service_dir"] = "/etc/service"
+  default["runit"]["service_dir"] = "/var/service"
   default["runit"]["sv_dir"] = "/var/service"
   default["runit"]["executable"] = "/sbin/runit"
   default["runit"]["start"] = "/etc/init.d/runit-start start"


### PR DESCRIPTION
If not, the service fail to start because, it cannot check if
# {service_dir_name}/supervise/ok is a pipe.

http://tickets.opscode.com/browse/COOK-2549
