### PR TITLE
[COOK-2322] Fix Debian init.d template

### DIFF
--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -411,7 +411,7 @@ EOF
             @lsb_init.mode(00755)
             @lsb_init.cookbook('runit')
             @lsb_init.source('init.d.erb')
-            @lsb_init.variables(:options => new_resource.options)
+            @lsb_init.variables(:name => new_resource.service_name)
           else
             @lsb_init = Chef::Resource::Link.new(::File.join( '/etc',
                                                               'init.d',

--- a/templates/debian/init.d.erb
+++ b/templates/debian/init.d.erb
@@ -1,18 +1,18 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:          <%= @params[:name] %>
+# Provides:          <%= @name %>
 # Required-Start:
 # Required-Stop:
 # Default-Start:
 # Default-Stop:
-# Short-Description: initscript for runit-managed <%= @params[:name] %> service
+# Short-Description: initscript for runit-managed <%= @name %> service
 ### END INIT INFO
 
 # Author: Opscode, Inc. <cookbooks@opscode.com>
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="runit-managed <%= @params[:name] %>"
-NAME=<%= @params[:name] %>
+DESC="runit-managed <%= @name %>"
+NAME=<%= @name %>
 RUNIT=/usr/bin/sv
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -30,16 +30,16 @@ SCRIPTNAME=/etc/init.d/$NAME
 case "$1" in
   start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
-        $RUNIT <%= @params[:start_command] %> $NAME
+        $RUNIT start $NAME
         [ "$VERBOSE" != no ] && log_end_msg $?
         ;;
   stop)
         [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-        $RUNIT <%= @params[:stop_command] %> $NAME
+        $RUNIT stop $NAME
         [ "$VERBOSE" != no ] && log_end_msg $?
         ;;
   status)
-        $RUNIT <%= @params[:status_command] %> $NAME && exit 0 || exit $?
+        $RUNIT status $NAME && exit 0 || exit $?
         ;;
   reload)
         [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$NAME"
@@ -53,7 +53,7 @@ case "$1" in
         ;;
   restart)
         [ "$VERBOSE" != no ] && log_daemon_msg "Restarting $DESC" "$NAME"
-        $RUNIT <%= @params[:restart_command] %> $NAME
+        $RUNIT restart $NAME
         [ "$VERBOSE" != no ] && log_end_msg $?
         ;;
   *)

--- a/test/spec/libraries/provider_runit_service_spec.rb
+++ b/test/spec/libraries/provider_runit_service_spec.rb
@@ -288,8 +288,8 @@ describe Chef::Provider::Service::Runit do
         provider.send(:lsb_init).mode.should eq(00755)
         provider.send(:lsb_init).cookbook.should eq('runit')
         provider.send(:lsb_init).source.should eq('init.d.erb')
-        provider.send(:lsb_init).variables.should have_key(:options)
-        provider.send(:lsb_init).variables[:options].should eq(new_resource.options)
+        provider.send(:lsb_init).variables.should have_key(:name)
+        provider.send(:lsb_init).variables[:name].should eq(new_resource.service_name)
       end
 
       it 'does not create anything in the sv_dir if it is nil or false' do


### PR DESCRIPTION
Ticket: http://tickets.opscode.com/browse/COOK-2322

[COOK-2254](http://tickets.opscode.com/browse/COOK-2254) left runit service broken on Debian. It was passing `:options` hash to the template that was still expecting `:params`. Just passing the `new_resource.options` is not a correct solution as that was meant for runit templates and is empty by default.

This commit fixes the issue by passing and using only the service name to the template. The runit commands are hardcoded the same way as they already are in the provider.
