### PR TITLE
[COOK-2760] installing runit failed on executing chef-solo under sudo

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -73,7 +73,7 @@ when "rhel"
   end
 
   rpm_package "runit-211" do
-    source "/root/rpmbuild/RPMS/runit-2.1.1.rpm"
+    source "#{ENV['HOME']}/rpmbuild/RPMS/runit-2.1.1.rpm"
     action :nothing
   end
 


### PR DESCRIPTION
sudo command does not change $HOME variable, then chef could not
found RPM file correctly if it runs under sudo.
