### PR TITLE
COOK-3013 block never execs if converge fails and chef-client rerun

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,9 +54,10 @@ when "rhel"
     package "buildsys-macros"
   end
 
+  rpm_installed = "rpm -qa | grep -q '^runit'"
   cookbook_file "#{Chef::Config[:file_cache_path]}/runit-2.1.1.tar.gz" do
     source "runit-2.1.1.tar.gz"
-    not_if "rpm -qa | grep -q '^runit'"
+    not_if rpm_installed
     notifies :run, "bash[rhel_build_install]", :immediately
   end
 
@@ -69,7 +70,8 @@ when "rhel"
       ./build.sh
     EOH
     notifies :install, "rpm_package[runit-211]", :immediately
-    action :nothing
+    action :run
+    not_if rpm_installed
   end
 
   rpm_package "runit-211" do


### PR DESCRIPTION
COOK-3013 - if a chef converge fails after the file is downloaded but before the rhel bash block runs, runit never gets installed.
