### PR TITLE
Assign to runit_attrs rather than compare

### DIFF
--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -240,7 +240,7 @@ class Chef
         if run_context && run_context.node
           runit_attr = run_context.node[:runit]
         else
-          runit_attr == {}
+          runit_attr = {}
         end
       end
     end


### PR DESCRIPTION
Fixes a bug that would cause chef to bail with the error:

```
NoMethodError
undefined method `[]' for false:FalseClass
```
