### PR TITLE
Fix runit RPM file location for Chef provisionless Centos 5.9 Box Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ runit Cookbook CHANGELOG
 ========================
 This file is used to list changes made in each version of the runit cookbook.
 
+v1.5.9
+------
+Fix runit RPM file location for Chef provisionless Centos 5.9 Box Image
+
 v1.5.8
 ------
 Fixing string interpolation bug

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,7 +72,7 @@ when 'rhel'
         cd runit-2.1.1
         ./build.sh
         rpm_root_dir=`rpm --eval '%{_rpmdir}'`
-        rpm -ivh '/root/rpmbuild/RPMS/runit-2.1.1.rpm'
+        rpm -ivh "${rpm_root_dir}/runit-2.1.1.rpm"
       EOH
       action :run
       not_if rpm_installed


### PR DESCRIPTION
I just started learning Chef and was using the memcached cookbook which depends on runit. I set up my box as per https://learnchef.opscode.com/quickstart/converge/ except I provisioned using their 'opscode_centos-5.9' official box image instead.

Upon knife bootstrap, I received the error message "error: open of /root/rpmbuild/RPMS/runit-2.1.1.rpm failed: No such file or directory"

This patch resolves the issue and allows runit to install. I have confirmed memcached via runit works now on Centos 5.9.
