### PR TITLE
Only include Yum on RHEL platforms

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,10 @@ recipe 'runit', 'Installs and configures runit'
 end
 
 depends 'build-essential'
+
+case node["platform_family"
+when "rhel"
 depends 'yum', '~> 3.0'
 depends 'yum-epel'
+end
 


### PR DESCRIPTION
There is no need to include the Yum cookbook on Debian-based systems, and sometimes causes dependency issues, especially in the complexity that is OpsWorks.

Error Resolving Cookbooks for Run List:
Missing Cookbooks:

Could not satisfy version constraints for: yum

Expanded Run List:

opsworks_initial_setup
ssh_host_keys
ssh_users
mysql::client
dependencies
ebs
opsworks_ganglia::client
opsworks_stack_state_sync
rabbitmq_cluster
deploy::default
test_suite
opsworks_cleanup
[2014-06-16T18:17:43+00:00] ERROR: Running exception handlers
[2014-06-16T18:17:43+00:00] ERROR: Exception handlers complete
[2014-06-16T18:17:43+00:00] FATAL: Stacktrace dumped to /var/lib/aws/opsworks/cache/chef-stacktrace.out
[2014-06-16T18:17:43+00:00] ERROR: 412 "Precondition Failed"
[2014-06-16T18:17:43+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
