### PR TITLE
#60 resolution: added container awareness to prevent "supervise/ok" bloc...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ runit Cookbook CHANGELOG
 ========================
 This file is used to list changes made in each version of the runit cookbook.
 
+v1.5.11 (2014-10-31)
+--------------------
+PR #69 - Fix issue #60 blocking 'supervise/ok' inside container
+
 v1.5.10 (2014-03-07)
 --------------------
 PR #53- Fix runit RPM file location for Chef provisionless Centos 5.9 Box Image

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs runit and provides runit_service definition'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.5.11'
+version           '1.5.12'
 
 recipe 'runit', 'Installs and configures runit'
 


### PR DESCRIPTION
If you run runit cookbook under docker container it will stuck. runit provider will fall into infinitive loop waiting for spuervise/ok (which will never happen for docker). While OHAI is not container aware yet, current PR adds checks if cookbook convergence happen inside container and skips supervise/ok wait.

Should work for different types of containers not only for docker where it was tested
