### PR TITLE
Enable runit installation in OEL systems

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,13 +8,16 @@ platforms:
   - name: centos-5.11
   - name: centos-6.7
   - name: centos-7.2
-  - name: oel-6.7
   - name: debian-7.10
     run_list: apt::default
   - name: debian-8.4
     run_list: apt::default
   - name: fedora-21
     run_list: yum::dnf_yum_compat
+  - name: oel-6.6
+    driver:
+      box: oel-6.6
+      box_url: https://atlas.hashicorp.com/rafacas/boxes/oel66-plain/versions/1.0.1/providers/virtualbox.box
   - name: ubuntu-12.04
     run_list: apt::default
   - name: ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ platforms:
   - name: centos-5.11
   - name: centos-6.7
   - name: centos-7.2
+  - name: oel-6.7
   - name: debian-7.10
     run_list: apt::default
   - name: debian-8.4
@@ -23,7 +24,7 @@ platforms:
 
 suites:
 - name: default
-  run_list:  
+  run_list:
   - recipe[runit_test]
   attributes: {}
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -66,4 +66,8 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:runit_service, :usr2, service)
   end
 
+  def add_packagecloud_repo(service)
+    ChefSpec::Matchers::ResourceMatcher.new(:packagecloud_repo, :add, service)
+  end
+
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,9 @@ when 'rhel', 'fedora'
   unless node['runit']['prefer_local_yum']
     include_recipe 'yum-epel' if node['platform_version'].to_i < 7
 
-    packagecloud_repo 'imeyer/runit'
+    packagecloud_repo 'imeyer/runit' do
+      force_os 'rhel' if node['platform'].eql?('oracle')
+    end
   end
 
   package 'runit'

--- a/test/unit/recipes/default_spec.rb
+++ b/test/unit/recipes/default_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+require 'spec_helper'
+
+describe 'runit::default' do
+  cached(:oel_65_default) do
+    ChefSpec::SoloRunner.new(
+      platform: 'oracle',
+      version: '6.5'
+    ) do |node|
+      node.set['runit']['version'] = '0.0'
+    end.converge(described_recipe)
+  end
+
+  it 'adds packagecloud_repo[imeyer/runit]' do
+    expect(oel_65_default).to add_packagecloud_repo('imeyer/runit')
+  end
+end


### PR DESCRIPTION
The `imeyer/runit` packagecloud repo does not have the ability to
resolve packages for OEL systems.

This commit enables `runit` cookbook to be able to install in OEL
systems by forcing the os platform to be `rhel` since that is the base
and packages should work the same way.

Pointing to packagecloud repo (master) in github since there is where
the new code for forcing exist. (Need to release it to Supermarket)