### PR TITLE
Move the default logger runscript from file to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Many of these parameters are only used in the `:enable` action.
 - **log** - Whether to start the service's logger with svlogd, requires a template `sv-service_name-log-run.erb` to configure the log's run script. Default is true.
 - **default_logger** - Whether a default `log/run` script should be set up. If true, the default content of the run script will use `svlogd` to write logs to `/var/log/service_name`. Default is false.
 - **log_dir** - The directory where the `svlogd` log service will run. Used when `default_logger` is `true`. Default is `/var/log/service_name`
+- **log_flags** - The flags to pass to the `svlogd` command. Used when `default_logger` is `true`. Default is `-tt`
 - **log_size** - The maximum size a log file can grow to before it is automatically rotated. See svlogd(8) for the default value.
 - **log_num** - The maximum number of log files that will be retained after rotation. See svlogd(8) for the default value.
 - **log_min** - The minimum number of log files that will be retained after rotation (if svlogd cannot create a new file and the minimum has not been reached, it will block). Default is no minimum.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -138,13 +138,6 @@ module RunitCookbook
       new_resource.cookbook.nil? ? new_resource.cookbook_name.to_s : new_resource.cookbook
     end
 
-    def default_logger_content
-      <<-EOS
-#!/bin/sh
-exec svlogd -tt #{new_resource.log_dir}
-      EOS
-    end
-
     def binary_exists?
       begin
         Chef::Log.debug("Checking to see if the runit binary exists by running #{new_resource.sv_bin}")

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -131,13 +131,15 @@ class Chef
             end
 
             if new_resource.default_logger
-              file "#{sv_dir_name}/log/run" do
-                content default_logger_content
+              template "#{sv_dir_name}/log/run" do
                 owner new_resource.owner unless new_resource.owner.nil?
                 group new_resource.group unless new_resource.group.nil?
                 mode '0755'
-                action :create
+                cookbook 'runit'
+                source 'log-run.erb'
+                variables(config: new_resource)
                 notifies :run, 'ruby_block[restart_log_service]', :delayed
+                action :create
               end
             else
               template "#{sv_dir_name}/log/run" do

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -68,6 +68,7 @@ class Chef
         @sv_timeout = nil
         @sv_verbose = false
         @log_dir = ::File.join('/var/log/', @service_name)
+        @log_flags = '-tt'
         @log_size = nil
         @log_num = nil
         @log_min = nil
@@ -231,6 +232,10 @@ class Chef
 
       def log_dir(arg = nil)
         set_or_return(:log_dir, arg, kind_of: [String])
+      end
+
+      def log_flags(arg = nil)
+        set_or_return(:log_flags, arg, kind_of: [String])
       end
 
       def log_size(arg = nil)

--- a/templates/default/log-run.erb
+++ b/templates/default/log-run.erb
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec svlogd <%= @config.log_flags %> <%= @config.log_dir %>

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -150,6 +150,12 @@ runit_service 'ayahuasca' do
   cookbook 'runit_other_test'
 end
 
+# Create a service with different svlogd flags
+runit_service 'ayahuasca' do
+  default_logger true
+  log_flags '-t'
+end
+
 # Note: this won't update the run script for the above due to
 # http://tickets.chef.io/browse/COOK-2353
 # runit_service 'the other name for yerba-alt' do


### PR DESCRIPTION
Signed-off-by: Patrick Cable <pc@pcable.net>

### Description

We would like to be able to remove the `-tt` flag from the default logger config, since our stdout log output also adds a timestamp (and is a json blob). By moving this to a template, we can customize this per service. I've left the default to `-tt` since that's a pretty reasonable default. 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
