### PR TITLE
Run `apt-get update` before installation of the package on Debian

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,7 @@ end
 
 depends 'packagecloud'
 depends 'yum-epel'
+depends 'apt'
 
 source_url 'https://github.com/chef-cookbooks/runit'
 issues_url 'https://github.com/chef-cookbooks/runit/issues'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,6 +46,7 @@ when 'rhel'
   end
 
 when 'debian'
+  include_recipe 'apt'
   package 'runit' do
     action :install
     response_file 'runit.seed'


### PR DESCRIPTION
I have the following error under Ubuntu:
```
        * apt_package[runit] action install[2017-03-15T04:48:24+00:00] INFO: Processing apt_package[runit] action install (runit::default line 49)

           * No candidate version available for runit
           ================================================================================
           Error executing action `install` on resource 'apt_package[runit]'
           ================================================================================

           Chef::Exceptions::Package
           -------------------------
           No candidate version available for runit

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/runit/recipes/default.rb

            49:   package 'runit' do
            50:     action :install
            51:     response_file 'runit.seed'
            52:   end
            53: end

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/runit/recipes/default.rb:49:in `from_file'

           apt_package("runit") do
             package_name "runit"
             action [:install]
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             declared_type :package
             cookbook_name "runit"
             recipe_name "default"
             response_file "runit.seed"
           end

           Platform:
           ---------
           x86_64-linux
```
This PR fixes it