### PR TITLE
Also install the runit-systemd package on newer Ubuntus

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -63,3 +63,10 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+
+- name: ubuntu-18.04
+  driver:
+    image: dokken/ubuntu-18.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,7 @@ platforms:
   - name: oracle-7
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
 
 suites:
 - name: default

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,7 +34,13 @@ when 'rhel', 'amazon'
 when 'debian'
   # debian 9+ ship with runit-systemd which includes only what you need for process supervision and not
   # what is necessary for running runit as pid 1, which we don't care about.
-  pkg_name = platform?('debian') && node['platform_version'].to_i >= 9 ? 'runit-systemd' : 'runit'
+  pv = node['platform_version']
+  pkg_name = if (platform?('debian') && pv.to_i >= 9) || \
+                (platform?('ubuntu') && Gem::Version.new(pv) >= Gem::Version.new('17.10'))
+               'runit-systemd'
+             else
+               'runit'
+             end
 
   package pkg_name do
     action :install

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -114,6 +114,24 @@ describe 'runit::default on ubuntu 16.04' do
   end
 end
 
+describe 'runit::default on ubuntu 18.04' do
+  cached(:ubuntu18_default) do
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '18.04'
+    ).converge('runit::default')
+  end
+
+  it 'installs the runit-systemd package' do
+    expect(ubuntu18_default).to install_package('runit-systemd')
+  end
+
+  it 'starts and enabled the correct runit service' do
+    expect(ubuntu18_default).to enable_service('runit')
+    expect(ubuntu18_default).to start_service('runit')
+  end
+end
+
 describe 'runit::default on debian 7' do
   cached(:debian7_default) do
     ChefSpec::SoloRunner.new(

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,4 +1,5 @@
-if os[:family] == 'debian' && os[:release].to_i == 9
+if (os[:name] == 'debian' && os[:release].to_i >= 9) || \
+   (os[:name] == 'ubuntu' && Gem::Version.new(os[:release]) >= Gem::Version.new('17.10'))
   describe package('runit-systemd') do
     it { should be_installed }
   end


### PR DESCRIPTION
### Description

Looks like it was introduced in 17.10.

https://packages.ubuntu.com/search?keywords=runit-systemd

With this addition, the cookbook now converges successfully on the prerelease
18.04 builds.

Signed-off-by: Jonathan Hartman <j@hartman.io>

### Issues Resolved

Cookbook fails to converge in Ubuntu 18.04 due to lacking a Systemd config.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
