### PR TITLE
Quoting the timeout value prevents it being cast to an unsigned long.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -117,7 +117,7 @@ module RunitCookbook
 
     def sv_args
       sv_args = ''
-      sv_args += "-w '#{new_resource.sv_timeout}' " unless new_resource.sv_timeout.nil?
+      sv_args += "-w #{new_resource.sv_timeout} " unless new_resource.sv_timeout.nil?
       sv_args += '-v ' if new_resource.sv_verbose
       sv_args
     end


### PR DESCRIPTION
### Description

When the timeout value is quoted, runit passes this value to scan_ulong which looks for numerals 0 to 9 only.

Without this change, sv respects has a timeout of zero regardless what is set in the runit_resource's sv_timeout property.

Obvious fix.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
