### PR TITLE
Fixing plat_specific_sv_name logic +  to work with Amazon Linux 2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs runit and provides runit_service resource'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.1.2'
+version '4.1.3'
 
 recipe 'runit', 'Installs and configures runit'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,7 @@ when 'rhel', 'amazon'
     packagecloud_repo 'imeyer/runit' do
       force_os 'rhel' if platform?('oracle', 'amazon') # ~FC024
       force_dist '6' if platform?('amazon')
+      force_dist '7' if platform?('amazon') && node['platform_version'].to_i == 2
       type 'rpm' if platform?('amazon')
     end
   end
@@ -62,6 +63,8 @@ plat_specific_sv_name = case node['platform_family']
                         when 'rhel'
                           if node['platform_version'].to_i >= 7 && !platform?('amazon')
                             'runsvdir-start'
+                          elsif node['platform_version'].to_i == 2 && platform?('amazon')
+                            'runsvdir-start'
                           else
                             'runsvdir'
                           end
@@ -72,6 +75,6 @@ plat_specific_sv_name = case node['platform_family']
 service plat_specific_sv_name do
   action [:start, :enable]
   # this might seem crazy, but RHEL 6 is in fact Upstart and the runit service is upstart there
-  provider Chef::Provider::Service::Upstart if platform?('amazon') || platform_family?('rhel') && node['platform_version'].to_i == 6
+  provider Chef::Provider::Service::Upstart if (platform?('amazon') || platform_family?('rhel')) && node['platform_version'].to_i == 6
   not_if { platform?('debian') && node['platform_version'].to_i < 8 } # there's no init script on debian 7...for reasons
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,6 +75,6 @@ plat_specific_sv_name = case node['platform_family']
 service plat_specific_sv_name do
   action [:start, :enable]
   # this might seem crazy, but RHEL 6 is in fact Upstart and the runit service is upstart there
-  provider Chef::Provider::Service::Upstart if (platform?('amazon') && node['platform_version'].to_i > 2) || (platform_family?('rhel') && node['platform_version'].to_i == 6)
+  provider Chef::Provider::Service::Upstart if (platform?('amazon') && node['platform_version'].to_i != 2) || (platform_family?('rhel') && node['platform_version'].to_i == 6)
   not_if { platform?('debian') && node['platform_version'].to_i < 8 } # there's no init script on debian 7...for reasons
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,6 +75,6 @@ plat_specific_sv_name = case node['platform_family']
 service plat_specific_sv_name do
   action [:start, :enable]
   # this might seem crazy, but RHEL 6 is in fact Upstart and the runit service is upstart there
-  provider Chef::Provider::Service::Upstart if (platform?('amazon') || platform_family?('rhel')) && node['platform_version'].to_i == 6
+  provider Chef::Provider::Service::Upstart if (platform?('amazon') && node['platform_version'].to_i > 2) || (platform_family?('rhel') && node['platform_version'].to_i == 6)
   not_if { platform?('debian') && node['platform_version'].to_i < 8 } # there's no init script on debian 7...for reasons
 end


### PR DESCRIPTION
### Description

Amazon Linux 2 uses `systemd` as opposed to Upstart; this change fixes the logic so that the recipe properly recognizes AL2:

1. Version 7 of `imeyer/runit` will be installed (confirmed that `runit-2.1.2-3.el7.centos.x86_64.rpm` does indeed work on AL2 + creates the necessary `runsvdir-start.service` file)
1. Use `runsvdir-start` for `plat_specific_sv_name` when using AL2
1. Only use Upstart on Amazon versions that are not AL2 (and/or RHEL 6)

### Issues Resolved

Installs correct `runit` package that is compatible with Amazon Linux 2 and uses the correct `plat_specific_sv_name` in order to start `runsvdir` via `systemctl`.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
