### PR TITLE
Preserve system PATH variable for init script.

### DIFF
--- a/templates/debian/init.d.erb
+++ b/templates/debian/init.d.erb
@@ -10,7 +10,7 @@
 
 # Author: Chef Software, Inc. <cookbooks@chef.io>
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
+PATH="$PATH:/sbin:/usr/sbin:/bin:/usr/bin"
 DESC="runit-managed <%= @name %>"
 NAME=<%= @name %>
 RUNIT=<%= @sv_bin %>

--- a/templates/ubuntu/init.d.erb
+++ b/templates/ubuntu/init.d.erb
@@ -10,7 +10,7 @@
 
 # Author: Chef Software, Inc. <cookbooks@chef.io>
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
+PATH="$PATH:/sbin:/usr/sbin:/bin:/usr/bin"
 DESC="runit-managed <%= @name %>"
 NAME=<%= @name %>
 RUNIT=<%= @sv_bin %>


### PR DESCRIPTION
### Description

This prevents the init scripts from overwriting the PATH environment variable when this is called. This fixes issues with omnibus applications where the path is outside of the hard-coded value.

### Issues Resolved

Internal issue SUSTAIN-985

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
