### PR TITLE
Use File.join to generate paths

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,16 +50,16 @@ module RunitCookbook
     end
 
     def down_file
-      "#{sv_dir_name}/down"
+      ::File.join(sv_dir_name, 'down')
     end
 
     def env_dir
-      "#{sv_dir_name}/env"
+      ::File.join(sv_dir_name, 'env')
     end
 
     def extra_env_files?
       files = []
-      Dir.glob("#{sv_dir_name}/env/*").each do |f|
+      Dir.glob(::File.join(sv_dir_name, 'env', '*')).each do |f|
         files << File.basename(f)
       end
       return true if files.sort != new_resource.env.keys.sort
@@ -67,7 +67,7 @@ module RunitCookbook
     end
 
     def delete_extra_env_files
-      Dir.glob("#{sv_dir_name}/env/*").each do |f|
+      Dir.glob(::File.join(sv_dir_name, 'env', '*')).each do |f|
         unless new_resource.env.key?(File.basename(f))
           File.unlink(f)
           Chef::Log.info("removing file #{f}")
@@ -78,10 +78,10 @@ module RunitCookbook
     def wait_for_service
       raise 'Runit does not appear to be installed. Include runit::default before using the resource!' unless binary_exists?
 
-      sleep 1 until ::FileTest.pipe?("#{service_dir_name}/supervise/ok")
+      sleep 1 until ::FileTest.pipe?(::File.join(service_dir_name, 'supervise', 'ok'))
 
       if new_resource.log
-        sleep 1 until ::FileTest.pipe?("#{service_dir_name}/log/supervise/ok")
+        sleep 1 until ::FileTest.pipe?(::File.join(service_dir_name, 'log', 'supervise', 'ok'))
       end
     end
 
@@ -99,20 +99,20 @@ module RunitCookbook
     end
 
     def log_running?
-      cmd = safe_sv_shellout("#{sv_args}status #{service_dir_name}/log", returns: [0, 100])
+      cmd = safe_sv_shellout("#{sv_args}status #{::File.join(service_dir_name, 'log')}", returns: [0, 100])
       !cmd.error? && cmd.stdout =~ /^run:/
     end
 
     def enabled?
-      ::File.exist?("#{service_dir_name}/run")
+      ::File.exist?(::File.join(service_dir_name, 'run'))
     end
 
     def log_service_name
-      "#{new_resource.service_name}/log"
+      ::File.join(new_resource.service_name, 'log')
     end
 
     def sv_dir_name
-      "#{parsed_sv_dir}/#{new_resource.service_name}"
+      ::File.join(parsed_sv_dir, new_resource.service_name)
     end
 
     def sv_args
@@ -127,11 +127,11 @@ module RunitCookbook
     end
 
     def service_dir_name
-      "#{new_resource.service_dir}/#{new_resource.service_name}"
+      ::File.join(new_resource.service_dir, new_resource.service_name)
     end
 
     def log_dir_name
-      "#{new_resource.service_dir}/#{new_resource.service_name}/log"
+      ::File.join(new_resource.service_dir, new_resource.service_name, log)
     end
 
     def template_cookbook
@@ -179,8 +179,8 @@ module RunitCookbook
       sleep(6)
       # runit will recreate the supervise directory and
       # pipes when the service is reenabled
-      Chef::Log.debug("Removing #{sv_dir_name}/supervise/ok")
-      FileUtils.rm("#{sv_dir_name}/supervise/ok")
+      Chef::Log.debug("Removing #{::File.join(sv_dir_name, 'supervise', 'ok')}")
+      FileUtils.rm(::File.join(sv_dir_name, 'supervise', 'ok'))
     end
 
     def start_service
@@ -196,7 +196,7 @@ module RunitCookbook
     end
 
     def restart_log_service
-      safe_sv_shellout!("#{sv_args}restart #{service_dir_name}/log")
+      safe_sv_shellout!("#{sv_args}restart #{::File.join(service_dir_name, 'log')}")
     end
 
     def reload_service
@@ -205,7 +205,7 @@ module RunitCookbook
 
     def reload_log_service
       if log_running?
-        safe_sv_shellout!("#{sv_args}force-reload #{service_dir_name}/log")
+        safe_sv_shellout!("#{sv_args}force-reload #{::File.join(service_dir_name, 'log')}")
       else
         Chef::Log.debug('Logging not running so doing nothing')
       end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -84,7 +84,7 @@ class Chef
             action :create
           end
 
-          template "#{sv_dir_name}/run" do
+          template ::File.join(sv_dir_name, 'run') do
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             source "sv-#{new_resource.run_template_name}-run.erb"
@@ -97,14 +97,14 @@ class Chef
 
           # log stuff
           if new_resource.log
-            directory "#{sv_dir_name}/log" do
+            directory ::File.join(sv_dir_name, 'log') do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               recursive true
               action :create
             end
 
-            directory "#{sv_dir_name}/log/main" do
+            directory ::File.join(sv_dir_name, 'log', 'main') do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode '0755'
@@ -120,7 +120,7 @@ class Chef
               action :create
             end
 
-            template "#{sv_dir_name}/log/config" do
+            template ::File.join(sv_dir_name, 'log', 'config') do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode '0644'
@@ -131,12 +131,12 @@ class Chef
               action :create
             end
 
-            link "#{new_resource.log_dir}/config" do
-              to "#{sv_dir_name}/log/config"
+            link ::File.join(new_resource.log_dir, 'config') do
+              to ::File.join(sv_dir_name, 'log', 'config')
             end
 
             if new_resource.default_logger
-              template "#{sv_dir_name}/log/run" do
+              template ::File.join(sv_dir_name, 'log', 'run') do
                 owner new_resource.owner unless new_resource.owner.nil?
                 group new_resource.group unless new_resource.group.nil?
                 mode '0755'
@@ -147,7 +147,7 @@ class Chef
                 action :create
               end
             else
-              template "#{sv_dir_name}/log/run" do
+              template ::File.join(sv_dir_name, 'log', 'run') do
                 owner new_resource.owner unless new_resource.owner.nil?
                 group new_resource.group unless new_resource.group.nil?
                 mode '0755'
@@ -162,7 +162,7 @@ class Chef
           end
 
           # environment stuff
-          directory "#{sv_dir_name}/env" do
+          directory ::File.join(sv_dir_name, 'env') do
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             mode '0755'
@@ -170,7 +170,7 @@ class Chef
           end
 
           new_resource.env.map do |var, value|
-            file "#{sv_dir_name}/env/#{var}" do
+            file ::File.join(sv_dir_name, 'env', var) do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               content value
@@ -189,7 +189,7 @@ class Chef
             notifies :run, 'ruby_block[restart_service]', :delayed
           end
 
-          template "#{sv_dir_name}/check" do
+          template ::File.join(sv_dir_name, 'check') do
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             mode '0755'
@@ -200,7 +200,7 @@ class Chef
             only_if { new_resource.check }
           end
 
-          template "#{sv_dir_name}/finish" do
+          template ::File.join(sv_dir_name, 'finish') do
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             mode '0755'
@@ -211,7 +211,7 @@ class Chef
             only_if { new_resource.finish }
           end
 
-          directory "#{sv_dir_name}/control" do
+          directory ::File.join(sv_dir_name, 'control') do
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             mode '0755'
@@ -219,7 +219,7 @@ class Chef
           end
 
           new_resource.control.map do |signal|
-            template "#{sv_dir_name}/control/#{signal}" do
+            template ::File.join(sv_dir_name, 'control', 'signal') do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode '0755'
@@ -232,12 +232,12 @@ class Chef
 
           # lsb_init
           if node['platform'] == 'debian' || node['platform'] == 'ubuntu'
-            ruby_block "unlink #{parsed_lsb_init_dir}/#{new_resource.service_name}" do
-              block { ::File.unlink("#{parsed_lsb_init_dir}/#{new_resource.service_name}") }
-              only_if { ::File.symlink?("#{parsed_lsb_init_dir}/#{new_resource.service_name}") }
+            ruby_block "unlink #{::File.join(parsed_lsb_init_dir, new_resource.service_name)}" do
+              block { ::File.unlink(::File.join(parsed_lsb_init_dir, new_resource.service_name)) }
+              only_if { ::File.symlink?(::File.join(parsed_lsb_init_dir, new_resource.service_name)) }
             end
 
-            template "#{parsed_lsb_init_dir}/#{new_resource.service_name}" do
+            template ::File.join(parsed_lsb_init_dir, new_resource.service_name) do
               owner 'root'
               group 'root'
               mode '0755'
@@ -252,7 +252,7 @@ class Chef
               action :create
             end
           else
-            link "#{parsed_lsb_init_dir}/#{new_resource.service_name}" do
+            link ::File.join(parsed_lsb_init_dir, new_resource.service_name) do
               to sv_bin
               action :create
             end
@@ -304,12 +304,12 @@ class Chef
 
         # Support supervisor owner and groups http://smarden.org/runit/faq.html#user
         if new_resource.supervisor_owner || new_resource.supervisor_group
-          directory "#{service_dir_name}/supervise" do
+          directory ::File.join(service_dir_name, 'supervise') do
             mode '0755'
             action :create
           end
           %w(ok status control).each do |target|
-            file "#{service_dir_name}/supervise/#{target}" do
+            file ::File.join(service_dir_name, 'supervise', target) do
               owner new_resource.supervisor_owner || 'root'
               group new_resource.supervisor_group || 'root'
               action :touch


### PR DESCRIPTION
### Description

Using `"#{foo}/#{bar}"` for generating paths is little error prone (for example, if someone makes a mistake and sets `foo = '/var/log/; bar = 'service'`, the path becomes `foo//bar` due to the trailing slash). Even though technically not an error, this may cause test failures where `foo/bar` is explicitly tested.

Using `::File.join` even though a bit of extra work, is safer.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
