### PR TITLE
Rewrite the resource to use the Chef provides DSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: trusty
+dist: xenial
 
 addons:
   apt:
@@ -19,16 +18,20 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=default-amazonlinux CHEF_VERSION=12.7.2
-  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=12.7.2
-  - INSTANCE=default-ubuntu-1604 CHEF_VERSION=12.7.2
-  - INSTANCE=default-debian-8 CHEF_VERSION=12.7.2
-  - INSTANCE=default-debian-9 CHEF_VERSION=12.7.2
-  - INSTANCE=default-centos-6 CHEF_VERSION=12.7.2
-  - INSTANCE=default-centos-7 CHEF_VERSION=12.7.2
+  - INSTANCE=default-amazonlinux CHEF_VERSION=13.0.118
+  - INSTANCE=default-amazonlinux-2 CHEF_VERSION=13.0.118
+  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=13.0.118
+  - INSTANCE=default-ubuntu-1604 CHEF_VERSION=13.0.118
+  - INSTANCE=default-ubuntu-1804 CHEF_VERSION=13.0.118
+  - INSTANCE=default-debian-8 CHEF_VERSION=13.0.118
+  - INSTANCE=default-debian-9 CHEF_VERSION=13.0.118
+  - INSTANCE=default-centos-6 CHEF_VERSION=13.0.118
+  - INSTANCE=default-centos-7 CHEF_VERSION=13.0.118
   - INSTANCE=default-amazonlinux
+  - INSTANCE=default-amazonlinux-2
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-ubuntu-1804
   - INSTANCE=default-debian-8
   - INSTANCE=default-debian-9
   - INSTANCE=default-centos-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ services: docker
 env:
   matrix:
   - INSTANCE=default-amazonlinux CHEF_VERSION=13.0.118
-  - INSTANCE=default-amazonlinux-2 CHEF_VERSION=13.0.118
   - INSTANCE=default-ubuntu-1404 CHEF_VERSION=13.0.118
   - INSTANCE=default-ubuntu-1604 CHEF_VERSION=13.0.118
   - INSTANCE=default-ubuntu-1804 CHEF_VERSION=13.0.118

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ For redhat derivatives:
 - Author:: Sean OMeara [sean@sean.io](mailto:sean@sean.io)
 
 ```text
-Copyright:: 2008-2016, Chef Software, Inc
+Copyright:: 2008-2019, Chef Software, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Many of these properties are only used in the `:enable` action.
 - **sv_timeout** - Override the default `sv` timeout of 7 seconds.
 - **sv_verbose** - Whether to enable `sv` verbose mode. Default is `false`.
 - **sv_templates** - If true, the `:enable` action will create the service directory with the appropriate templates. Default is `true`. Set this to `false` if the service has a package that provides its own service directory. See **Usage** examples.
-- **options** - Options passed as variables to templates, for compatibility with legacy runit service definition. Default is an empty hash.
+- **options** - DEPRECATED - Options passed as variables to templates, for compatibility with legacy runit service definition. Default is an empty hash.
 - **env** - A hash of environment variables with their values as content used in the service's `env` directory. Default is an empty hash. When this hash is non-empty, the contents of the runit service's `env` directory will be managed by Chef in order to conform to the declared state.
 - **log** - Whether to start the service's logger with svlogd, requires a template `sv-service_name-log-run.erb` to configure the log's run script. Default is true.
 - **default_logger** - Whether a default `log/run` script should be set up. If true, the default content of the run script will use `svlogd` to write logs to `/var/log/service_name`. Default is false.

--- a/README.md
+++ b/README.md
@@ -28,16 +28,6 @@ For more information about runit:
 
 ## Attributes
 
-See `attributes/default.rb` for defaults generated per platform.
-
-- `node['runit']['sv_bin']` - Full path to the `sv` binary.
-- `node['runit']['chpst_bin']` - Full path to the `chpst` binary.
-- `node['runit']['service_dir']` - Full path to the default "services" directory where enabled services are linked.
-- `node['runit']['sv_dir']` - Full path to the directory where service lives, which gets linked to `service_dir`.
-- `node['runit']['lsb_init_dir']` - Full path to the directory where the LSB-compliant init script interface will be created.
-
-### Optional Attributes for RHEL systems
-
 - `node['runit']['prefer_local_yum']` - If `true`, assumes that a `runit` package is available on an already configured local yum repository. By default, the recipe installs the `runit` package from a Package Cloud repository (see below). This is set to the value of `node['runit']['use_package_from_yum']` for backwards compatibility, but otherwise defaults to `false`.
 
 ## Recipes
@@ -53,8 +43,6 @@ On Debian family systems, the runit packages are maintained by the runit author,
 ## Resource
 
 This cookbook has a resource, `runit_service`, for managing services under runit.
-
-**This resource replaces the runit_service definition. See the CHANGELOG.md file in this cookbook for breaking change information and any actions you may need to take to update cookbooks using runit_service.**
 
 ### Actions
 
@@ -81,7 +69,7 @@ Read the `sv(8)` [man page](http://smarden.org/runit/sv.8.html) for more informa
 
 ### Properties
 
-The first three properties, `sv_dir`, `service_dir`, and `sv_bin` will attempt to use the corresponding node attributes, and fall back to hardcoded default values that match the settings used on Debian platform systems.
+The first three properties, `sv_dir`, `service_dir`, and `sv_bin` will attempt to use the legacy node attributes, and fall back to hardcoded default values that match the settings used on Debian platform systems.
 
 Many of these properties are only used in the `:enable` action.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information about runit:
 
 ### Chef
 
-- Chef 12.1+
+- Chef 13.0+
 
 ### Cookbooks
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit
 # Attribute:: File:: sv_bin
 #
-# Copyright:: 2008-2016, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit
 # Attribute:: File:: sv_bin
 #
-# Copyright:: 2008-2019, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -17,21 +17,9 @@
 # limitations under the License.
 #
 
-case node['platform_family']
-when 'debian'
   default['runit']['sv_bin'] = '/usr/bin/sv'
   default['runit']['chpst_bin'] = '/usr/bin/chpst'
   default['runit']['service_dir'] = '/etc/service'
   default['runit']['sv_dir'] = '/etc/sv'
   default['runit']['lsb_init_dir'] = '/etc/init.d'
   default['runit']['executable'] = '/sbin/runit'
-
-when 'rhel', 'amazon'
-  default['runit']['sv_bin'] = '/sbin/sv'
-  default['runit']['chpst_bin'] = '/sbin/chpst'
-  default['runit']['service_dir'] = '/etc/service'
-  default['runit']['sv_dir'] = '/etc/sv'
-  default['runit']['lsb_init_dir'] = '/etc/init.d'
-  default['runit']['executable'] = '/sbin/runit'
-  default['runit']['prefer_local_yum'] = node['runit']['use_package_from_yum'] || false
-end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,9 +17,4 @@
 # limitations under the License.
 #
 
-  default['runit']['sv_bin'] = '/usr/bin/sv'
-  default['runit']['chpst_bin'] = '/usr/bin/chpst'
-  default['runit']['service_dir'] = '/etc/service'
-  default['runit']['sv_dir'] = '/etc/sv'
-  default['runit']['lsb_init_dir'] = '/etc/init.d'
-  default['runit']['executable'] = '/sbin/runit'
+default['runit']['prefer_local_yum'] = node['runit']['use_package_from_yum'] || false

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -19,6 +19,11 @@ platforms:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
 
+- name: amazonlinux-2
+  driver:
+    image: dokken/amazonlinux-2
+    pid_one_command: /usr/lib/systemd/systemd
+
 - name: debian-8
   driver:
     image: dokken/debian-8

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -107,10 +107,6 @@ module RunitCookbook
       ::File.join(new_resource.service_dir, new_resource.service_name, log)
     end
 
-    def template_cookbook
-      new_resource.cookbook.nil? ? new_resource.cookbook_name.to_s : new_resource.cookbook
-    end
-
     def binary_exists?
       begin
         Chef::Log.debug("Checking to see if the runit binary exists by running #{new_resource.sv_bin}")

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,9 +1,9 @@
 #
 # Cookbook:: runit
-# Libraries:: helpers
+# Library:: helpers
 #
-# Author: Joshua Timberman <joshua@chef.io>
-# Author: Sean OMeara <sean@sean.io>
+# Author:: Joshua Timberman <joshua@chef.io>
+# Author:: Sean OMeara <sean@sean.io>
 # Copyright:: 2008-2016, Chef Software, Inc. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -89,7 +89,7 @@ module RunitCookbook
     end
 
     def sv_dir_name
-      ::File.join(parsed_sv_dir, new_resource.service_name)
+      ::File.join(new_resource.sv_dir, new_resource.service_name)
     end
 
     def sv_args

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,9 +23,7 @@ module RunitCookbook
   module Helpers
     # include Chef::Mixin::ShellOut if it is not already included in the calling class
     def self.included(klass)
-      unless klass.ancestors.include?(Chef::Mixin::ShellOut)
-        klass.class_eval { include Chef::Mixin::ShellOut }
-      end
+      klass.class_eval { include Chef::Mixin::ShellOut } unless klass.ancestors.include?(Chef::Mixin::ShellOut)
     end
 
     def down_file

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Joshua Timberman <joshua@chef.io>
 # Author:: Sean OMeara <sean@sean.io>
-# Copyright:: 2008-2016, Chef Software, Inc. <legal@chef.io>
+# Copyright:: 2008-2019, Chef Software, Inc. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -28,27 +28,6 @@ module RunitCookbook
       end
     end
 
-    # Default settings for resource properties.
-    def parsed_sv_bin
-      return new_resource.sv_bin if new_resource.sv_bin
-      '/usr/bin/sv'
-    end
-
-    def parsed_sv_dir
-      return new_resource.sv_dir if new_resource.sv_dir
-      '/etc/sv'
-    end
-
-    def parsed_service_dir
-      return new_resource.service_dir if new_resource.service_dir
-      '/etc/service'
-    end
-
-    def parsed_lsb_init_dir
-      return new_resource.lsb_init_dir if new_resource.lsb_init_dir
-      '/etc/init.d'
-    end
-
     def down_file
       ::File.join(sv_dir_name, 'down')
     end
@@ -122,10 +101,6 @@ module RunitCookbook
       sv_args
     end
 
-    def sv_bin
-      parsed_sv_bin
-    end
-
     def service_dir_name
       ::File.join(new_resource.service_dir, new_resource.service_name)
     end
@@ -151,8 +126,8 @@ module RunitCookbook
 
     def safe_sv_shellout(command, options = {})
       begin
-        Chef::Log.debug("Attempting to run runit command: #{sv_bin} #{command}")
-        cmd = shell_out("#{sv_bin} #{command}", options)
+        Chef::Log.debug("Attempting to run runit command: #{new_resource.sv_bin} #{command}")
+        cmd = shell_out("#{new_resource.sv_bin} #{command}", options)
       rescue Errno::ENOENT
         if binary_exists?
           raise # Some other cause

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -86,7 +86,7 @@ class Chef
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             source "sv-#{new_resource.run_template_name}-run.erb"
-            cookbook template_cookbook
+            cookbook new_resource.cookbook
             mode '0755'
             variables(options: new_resource.options)
             action :create
@@ -150,7 +150,7 @@ class Chef
                 group new_resource.group unless new_resource.group.nil?
                 mode '0755'
                 source "sv-#{new_resource.log_template_name}-log-run.erb"
-                cookbook template_cookbook
+                cookbook new_resource.cookbook
                 variables(options: new_resource.options)
                 action :create
                 notifies :run, 'ruby_block[restart_log_service]', :delayed
@@ -191,7 +191,7 @@ class Chef
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             mode '0755'
-            cookbook template_cookbook
+            cookbook new_resource.cookbook
             source "sv-#{new_resource.check_script_template_name}-check.erb"
             variables(options: new_resource.options)
             action :create
@@ -203,7 +203,7 @@ class Chef
             group new_resource.group unless new_resource.group.nil?
             mode '0755'
             source "sv-#{new_resource.finish_script_template_name}-finish.erb"
-            cookbook template_cookbook
+            cookbook new_resource.cookbook
             variables(options: new_resource.options) if new_resource.options.respond_to?(:has_key?)
             action :create
             only_if { new_resource.finish }
@@ -222,7 +222,7 @@ class Chef
               group new_resource.group unless new_resource.group.nil?
               mode '0755'
               source "sv-#{new_resource.control_template_names[signal]}-#{signal}.erb"
-              cookbook template_cookbook
+              cookbook new_resource.cookbook
               variables(options: new_resource.options)
               action :create
             end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: runit
-# Provider:: service
+# Provider:: runit_service
 #
 # Author:: Joshua Timberman <jtimberman@chef.io>
 # Author:: Sean OMeara <sean@sean.io>

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -46,8 +46,6 @@ class Chef
 
       # actions
       action :create do
-        create_service_mirror
-
         ruby_block 'restart_service' do
           block do
             previously_enabled = enabled?
@@ -274,8 +272,6 @@ class Chef
       end
 
       action :disable do
-        create_service_mirror
-
         ruby_block "disable #{new_resource.service_name}" do
           block { disable_service }
           only_if { enabled? }
@@ -283,7 +279,6 @@ class Chef
       end
 
       action :enable do
-        create_service_mirror
         action_create
 
         directory new_resource.service_dir
@@ -329,13 +324,10 @@ class Chef
       end
 
       action :restart do
-        create_service_mirror
         restart_service
       end
 
       action :start do
-        create_service_mirror
-
         if running?
           Chef::Log.debug "#{new_resource} already running - nothing to do"
         else
@@ -345,7 +337,6 @@ class Chef
       end
 
       action :stop do
-        create_service_mirror
         if running?
           stop_service
           Chef::Log.info "#{new_resource} stopped"
@@ -355,8 +346,6 @@ class Chef
       end
 
       action :reload do
-        create_service_mirror
-
         if running?
           reload_service
           Chef::Log.info "#{new_resource} reloaded"
@@ -366,7 +355,6 @@ class Chef
       end
 
       action :status do
-        create_service_mirror
         running?
       end
     end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Joshua Timberman <jtimberman@chef.io>
 # Author:: Sean OMeara <sean@sean.io>
-# Copyright:: 2011-2016, Chef Software, Inc.
+# Copyright:: 2011-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@
 class Chef
   class Provider
     class RunitService < Chef::Provider::LWRPBase
+      provides :runit_service
+
       unless defined?(VALID_SIGNALS)
         # Mapping of valid signals with optional friendly name
         VALID_SIGNALS = Mash.new(
@@ -37,12 +39,6 @@ class Chef
           1 => :usr1,
           2 => :usr2
         )
-      end
-
-      use_inline_resources # ~FC113
-
-      def whyrun_supported?
-        true
       end
 
       # Mix in helpers from libraries/helpers.rb

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -228,12 +228,12 @@ class Chef
 
           # lsb_init
           if node['platform'] == 'debian' || node['platform'] == 'ubuntu'
-            ruby_block "unlink #{::File.join(parsed_lsb_init_dir, new_resource.service_name)}" do
-              block { ::File.unlink(::File.join(parsed_lsb_init_dir, new_resource.service_name)) }
-              only_if { ::File.symlink?(::File.join(parsed_lsb_init_dir, new_resource.service_name)) }
+            ruby_block "unlink #{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}" do
+              block { ::File.unlink("#{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}") }
+              only_if { ::File.symlink?("#{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}") }
             end
 
-            template ::File.join(parsed_lsb_init_dir, new_resource.service_name) do
+            template ::File.join(new_resource.lsb_init_dir, new_resource.service_name) do
               owner 'root'
               group 'root'
               mode '0755'
@@ -243,12 +243,12 @@ class Chef
                 name: new_resource.service_name,
                 sv_bin: new_resource.sv_bin,
                 sv_args: sv_args,
-                init_dir: ::File.join(parsed_lsb_init_dir, '')
+                init_dir: ::File.join(new_resource.lsb_init_dir, '')
               )
               action :create
             end
           else
-            link ::File.join(parsed_lsb_init_dir, new_resource.service_name) do
+            link ::File.join(new_resource.lsb_init_dir, new_resource.service_name) do
               to sv_bin
               action :create
             end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -281,7 +281,6 @@ class Chef
       end
 
       action :enable do
-        # FIXME: remove action_create in next major version
         action_create
 
         directory new_resource.service_dir

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -44,22 +44,6 @@ class Chef
       # Mix in helpers from libraries/helpers.rb
       include RunitCookbook::Helpers
 
-      # this exists to allow folks to notify to a service resource instead of a runit_service resource
-      # almost everyone has written cookbooks notifying to service so we need to continue this behavior
-      def create_service_mirror
-        with_run_context(:parent) do
-          find_resource(:service, new_resource.name) do # creates if it does not exist
-            provider Chef::Provider::Service::Simple
-            supports new_resource.supports
-            start_command "#{new_reource.sv_bin} start #{new_resource.service_dir_name}"
-            stop_command "#{new_resource.sv_bin} stop #{new_resource.service_dir_name}"
-            restart_command "#{new_resource.sv_bin} restart #{new_resource.service_dir_name}"
-            status_command "#{new_resource.sv_bin} status #{new_resource.service_dir_name}"
-            action :nothing
-          end
-        end
-      end
-
       # actions
       action :create do
         create_service_mirror

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -326,9 +326,6 @@ class Chef
         end
       end
 
-      action :nothing do
-      end
-
       action :restart do
         restart_service
       end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -44,6 +44,8 @@ class Chef
       # Mix in helpers from libraries/helpers.rb
       include RunitCookbook::Helpers
 
+      # this exists to allow folks to notify to a service resource instead of a runit_service resource
+      # almost everyone has written cookbooks notifying to service so we need to continue this behavior
       def create_service_mirror
         with_run_context(:parent) do
           find_resource(:service, new_resource.name) do # creates if it does not exist
@@ -61,6 +63,7 @@ class Chef
       # actions
       action :create do
         create_service_mirror
+
         ruby_block 'restart_service' do
           block do
             previously_enabled = enabled?
@@ -86,7 +89,6 @@ class Chef
 
         # sv_templates
         if new_resource.sv_templates
-
           directory sv_dir_name do
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
@@ -169,7 +171,6 @@ class Chef
                 notifies :run, 'ruby_block[restart_log_service]', :delayed
               end
             end
-
           end
 
           # environment stuff
@@ -290,6 +291,7 @@ class Chef
 
       action :disable do
         create_service_mirror
+
         ruby_block "disable #{new_resource.service_name}" do
           block { disable_service }
           only_if { enabled? }
@@ -349,6 +351,7 @@ class Chef
 
       action :start do
         create_service_mirror
+
         if running?
           Chef::Log.debug "#{new_resource} already running - nothing to do"
         else
@@ -369,6 +372,7 @@ class Chef
 
       action :reload do
         create_service_mirror
+
         if running?
           reload_service
           Chef::Log.info "#{new_resource} reloaded"

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -46,8 +46,6 @@ class Chef
 
       # actions
       action :create do
-        declare_service_resource
-
         ruby_block 'restart_service' do
           block do
             previously_enabled = enabled?
@@ -283,8 +281,6 @@ class Chef
       end
 
       action :enable do
-        declare_service_resource
-
         action_create
 
         directory new_resource.service_dir
@@ -330,13 +326,10 @@ class Chef
       end
 
       action :restart do
-        declare_service_resource
         restart_service
       end
 
       action :start do
-        declare_service_resource
-
         if running?
           Chef::Log.debug "#{new_resource} already running - nothing to do"
         else
@@ -365,30 +358,6 @@ class Chef
 
       action :status do
         running?
-      end
-
-      #
-      # Backward Compat Hack
-      #
-      # This ensures a 'service' resource exists for all 'runit_service' resources.
-      # This should allow all recipes using the previous 'runit_service' definition to
-      # continue operating.
-      #
-      def declare_service_resource
-        service_dir_name = ::File.join(new_resource.service_dir, new_resource.service_name)
-
-        Chef::Log.warn(new_resource.service_name)
-        with_run_context(:parent) do
-          service new_resource.service_name do
-            provider Chef::Provider::Service::Simple
-            supports new_resource.supports
-            start_command "#{new_resource.sv_bin} start #{service_dir_name}"
-            stop_command "#{new_resource.sv_bin} stop #{service_dir_name}"
-            restart_command "#{new_resource.sv_bin} restart #{service_dir_name}"
-            status_command "#{new_resource.sv_bin} status #{service_dir_name}"
-            action :nothing
-          end
-        end
       end
     end
   end

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -231,8 +231,8 @@ class Chef
           # lsb_init
           if node['platform'] == 'debian' || node['platform'] == 'ubuntu'
             ruby_block "unlink #{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}" do
-              block { ::File.unlink("#{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}") }
-              only_if { ::File.symlink?("#{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}") }
+              block { ::File.unlink(::File.join(new_resource.lsb_init_dir, new_resource.service_name).to_s) }
+              only_if { ::File.symlink?(::File.join(new_resource.lsb_init_dir, new_resource.service_name).to_s) }
             end
 
             template ::File.join(new_resource.lsb_init_dir, new_resource.service_name) do

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -172,7 +172,7 @@ class Chef
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               content value
-              sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
+              sensitive true
               mode '0640'
               action :create
               notifies :run, 'ruby_block[restart_service]', :delayed

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -46,6 +46,8 @@ class Chef
 
       # actions
       action :create do
+        declare_service_resource
+
         ruby_block 'restart_service' do
           block do
             previously_enabled = enabled?
@@ -281,6 +283,8 @@ class Chef
       end
 
       action :enable do
+        declare_service_resource
+
         action_create
 
         directory new_resource.service_dir
@@ -326,10 +330,13 @@ class Chef
       end
 
       action :restart do
+        declare_service_resource
         restart_service
       end
 
       action :start do
+        declare_service_resource
+
         if running?
           Chef::Log.debug "#{new_resource} already running - nothing to do"
         else
@@ -358,6 +365,30 @@ class Chef
 
       action :status do
         running?
+      end
+
+      #
+      # Backward Compat Hack
+      #
+      # This ensures a 'service' resource exists for all 'runit_service' resources.
+      # This should allow all recipes using the previous 'runit_service' definition to
+      # continue operating.
+      #
+      def declare_service_resource
+        service_dir_name = ::File.join(new_resource.service_dir, new_resource.service_name)
+
+        Chef::Log.warn(new_resource.service_name)
+        with_run_context(:parent) do
+          service new_resource.service_name do
+            provider Chef::Provider::Service::Simple
+            supports new_resource.supports
+            start_command "#{new_resource.sv_bin} start #{service_dir_name}"
+            stop_command "#{new_resource.sv_bin} stop #{service_dir_name}"
+            restart_command "#{new_resource.sv_bin} restart #{service_dir_name}"
+            status_command "#{new_resource.sv_bin} status #{service_dir_name}"
+            action :nothing
+          end
+        end
       end
     end
   end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -89,30 +89,6 @@ class Chef
       def default_options
         env.empty? ? {} : { env_dir: ::File.join(sv_dir, service_name, 'env') }
       end
-
-      def initialize(name, run_context = nil)
-        super
-
-        #
-        # Backward Compat Hack
-        #
-        # This ensures a 'service' resource exists for all 'runit_service' resources.
-        # This should allow all recipes using the previous 'runit_service' definition to
-        # continue operating.
-        #
-        unless run_context.nil?
-          service_dir_name = ::File.join(service_dir, name)
-          @service_mirror = Chef::Resource::Service.new(name, run_context)
-          @service_mirror.provider(Chef::Provider::Service::Simple)
-          @service_mirror.supports(supports)
-          @service_mirror.start_command("#{sv_bin} start #{service_dir_name}")
-          @service_mirror.stop_command("#{sv_bin} stop #{service_dir_name}")
-          @service_mirror.restart_command("#{sv_bin} restart #{service_dir_name}")
-          @service_mirror.status_command("#{sv_bin} status #{service_dir_name}")
-          @service_mirror.action(:nothing)
-          run_context.resource_collection.insert(@service_mirror)
-        end
-      end
     end
   end
 end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -75,6 +75,30 @@ class Chef
 
       alias template_name run_template_name
 
+      def initialize(name, run_context = nil)
+        super
+        #
+        # Backward Compat Hack
+        #
+        # This ensures a 'service' resource exists for all 'runit_service' resources.
+        # This should allow all recipes using the previous 'runit_service' definition to
+        # continue operating.
+        #
+        unless run_context.nil?
+          service_dir_name = ::File.join(service_dir, service_name)
+          @service_mirror = Chef::Resource::Service.new(name, run_context)
+          @service_mirror.provider(Chef::Provider::Service::Simple)
+          @service_mirror.supports(supports)
+          @service_mirror.start_command("#{sv_bin} start #{service_dir_name}")
+          @service_mirror.stop_command("#{sv_bin} stop #{service_dir_name}")
+          @service_mirror.restart_command("#{sv_bin} restart #{service_dir_name}")
+          @service_mirror.status_command("#{sv_bin} status #{service_dir_name}")
+          @service_mirror.action(:nothing)
+          run_context.resource_collection.insert(@service_mirror)
+        end
+      end
+
+
       def set_control_template_names
         template_names = {}
         control.each do |signal|

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -31,7 +31,7 @@ class Chef
       allowed_actions :nothing, :start, :stop, :enable, :disable, :restart, :reload, :status, :once, :hup, :cont, :term, :kill, :up, :down, :usr1, :usr2, :create
 
       # For legacy reasons we allow setting these via attribute
-      property :sv_bin, String, default: lazy { node['runit']['sv_bin'] || '/usr/bin/sv' }
+      property :sv_bin, String, default: lazy { node['runit']['sv_bin'] || ( platform_family?('debian') ? '/usr/bin/sv' : '/sbin/sv' ) }
       property :sv_dir, [String, FalseClass], default: lazy { node['runit']['sv_dir'] || '/etc/sv' }
       property :service_dir, String, default: lazy { node['runit']['service_dir'] || '/etc/service' }
       property :lsb_init_dir, String, default: lazy { node['runit']['lsb_init_dir'] || '/etc/init.d' }

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -37,7 +37,7 @@ class Chef
       property :lsb_init_dir, String, default: lazy { node['runit']['lsb_init_dir'] || '/etc/init.d' }
 
       property :control, Array, default: []
-      property :options, Hash, default: lazy {default_options}
+      property :options, Hash, default: lazy { default_options }, coerce: proc { |r| default_options.merge(r) if r.respond_to?(:merge) }
       property :env, Hash, default: {}
       property :log, [TrueClass, FalseClass], default: true
       property :cookbook, String
@@ -86,7 +86,7 @@ class Chef
       #
       # @return [Hash] an empty hash if env property is set. Otherwise it's env_dir
       def default_options
-        env.empty? ? {} : {env_dir: ::File.join(sv_dir, service_name, 'env')}
+        env.empty? ? {} : { env_dir: ::File.join(sv_dir, service_name, 'env') }
       end
 
       def initialize(name, run_context = nil)
@@ -112,19 +112,6 @@ class Chef
           run_context.resource_collection.insert(@service_mirror)
         end
       end
-
-      # def options(arg = nil)
-      #   default_opts = @env.empty? ? @options : @options.merge(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
-      #
-      #   merged_opts = arg.respond_to?(:merge) ? default_opts.merge(arg) : default_opts
-      #
-      #   set_or_return(
-      #     :options,
-      #     merged_opts,
-      #     kind_of: [Hash],
-      #     default: default_opts
-      #   )
-      # end
     end
   end
 end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook:: runit
-# Provider:: service
+# resource:: runit_service
 #
-# Copyright:: 2011-2016, Joshua Timberman
+# Author:: Joshua Timberman <jtimberman@chef.io>
 # Copyright:: 2011-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ class Chef
       property :lsb_init_dir, String, default: lazy { node['runit']['lsb_init_dir'] || '/etc/init.d' }
 
       property :control, Array, default: []
-      property :options, Hash, default: {}
+      property :options, Hash, default: lazy {default_options}
       property :env, Hash, default: {}
       property :log, [TrueClass, FalseClass], default: true
       property :cookbook, String
@@ -80,6 +80,13 @@ class Chef
           control_template_names[signal] ||= service_name
         end
         control_template_names
+      end
+
+      # the default legacy options kept for compatibility with the definition
+      #
+      # @return [Hash] an empty hash if env property is set. Otherwise it's env_dir
+      def default_options
+        env.empty? ? {} : {env_dir: ::File.join(sv_dir, service_name, 'env')}
       end
 
       def initialize(name, run_context = nil)

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -3,7 +3,7 @@
 # Provider:: service
 #
 # Copyright:: 2011-2016, Joshua Timberman
-# Copyright:: 2011-2016, Chef Software, Inc.
+# Copyright:: 2011-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,58 +25,65 @@ class Chef
   class Resource
     # Missing top-level class documentation comment
     class RunitService < Chef::Resource::Service
+      resource_name :runit_service
+
+      default_action :enable
+      allowed_actions :nothing, :start, :stop, :enable, :disable, :restart, :reload, :status, :once, :hup, :cont, :term, :kill, :up, :down, :usr1, :usr2, :create
+
+      # For legacy reasons we allow setting these via attribute
+      property :sv_bin, String, default: lazy { node['runit']['sv_bin'] || '/usr/bin/sv' }
+      property :sv_dir, [String, FalseClass], default: lazy { node['runit']['sv_dir'] || '/etc/sv' }
+      property :service_dir, String, default: lazy { node['runit']['service_dir'] || '/etc/service' }
+      property :lsb_init_dir, String, default: lazy { node['runit']['lsb_init_dir'] || '/etc/init.d' }
+
+      property :control, Array, default: []
+      property :options, Hash, default: {}
+      property :env, Hash, default: {}
+      property :log, [TrueClass, FalseClass], default: true
+      property :cookbook, String
+      property :check, [TrueClass, FalseClass], default: false
+      property :start_down, [TrueClass, FalseClass], default: false
+      property :delete_downfile, [TrueClass, FalseClass], default: false
+      property :finish, [TrueClass, FalseClass], default: false
+      property :supervisor_owner, String, regex: [Chef::Config[:user_valid_regex]]
+      property :supervisor_group, String, regex: [Chef::Config[:group_valid_regex]]
+      property :owner, String, regex: [Chef::Config[:user_valid_regex]]
+      property :group, String, regex: [Chef::Config[:group_valid_regex]]
+      property :enabled, [TrueClass, FalseClass], default: false
+      property :running, [TrueClass, FalseClass], default: false
+      property :default_logger, [TrueClass, FalseClass], default: false
+      property :restart_on_update, [TrueClass, FalseClass], default: true
+      property :run_template_name, String, default: lazy { service_name }
+      property :log_template_name, String, default: lazy { service_name }
+      property :check_script_template_name, String, default: lazy { service_name }
+      property :finish_script_template_name, String, default: lazy { service_name }
+      property :control_template_names, Hash, default: lazy { set_control_template_names }
+      property :status_command, String, default: lazy { "#{sv_bin} status #{service_dir}" }
+      property :sv_templates, [TrueClass, FalseClass], default: true
+      property :sv_timeout, Integer
+      property :sv_verbose, [TrueClass, FalseClass], default: false
+      property :log_dir, String, default: lazy { ::File.join('/var/log/', service_name) }
+      property :log_flags, String, default: '-tt'
+      property :log_size, Integer
+      property :log_num, Integer
+      property :log_min, Integer
+      property :log_timeout, Integer
+      property :log_processor, String
+      property :log_socket, [String, Hash]
+      property :log_prefix, String
+      property :log_config_append, String
+
+      alias template_name run_template_name
+
+      def set_control_template_names
+        control.each do |signal|
+          control_template_names[signal] ||= service_name
+        end
+        control_template_names
+      end
+
       def initialize(name, run_context = nil)
         super
-        runit_node = runit_attributes_from_node(run_context)
-        @resource_name = :runit_service
-        @provider = Chef::Provider::RunitService
-        @supports = { restart: true, reload: true, status: true }
-        @action = :enable
-        @allowed_actions = [:nothing, :start, :stop, :enable, :disable, :restart, :reload, :status, :once, :hup, :cont, :term, :kill, :up, :down, :usr1, :usr2, :create]
-
-        # sv_bin, sv_dir, service_dir and lsb_init_dir may have been set in the
-        # node attributes
-        @sv_bin = runit_node[:sv_bin] || '/usr/bin/sv'
-        @sv_dir = runit_node[:sv_dir] || '/etc/sv'
-        @service_dir = runit_node[:service_dir] || '/etc/service'
-        @lsb_init_dir = runit_node[:lsb_init_dir] || '/etc/init.d'
-
-        @control = []
-        @options = {}
-        @env = {}
-        @log = true
-        @cookbook = nil
-        @check = false
-        @start_down = false
-        @delete_downfile = false
-        @finish = false
-        @supervisor_owner = nil
-        @supervisor_group = nil
-        @owner = nil
-        @group = nil
-        @enabled = false
-        @running = false
-        @default_logger = false
-        @restart_on_update = true
-        @run_template_name = @service_name
-        @log_template_name = @service_name
-        @check_script_template_name = @service_name
-        @finish_script_template_name = @service_name
-        @control_template_names = {}
-        @status_command = "#{@sv_bin} status #{@service_dir}"
-        @sv_templates = true
-        @sv_timeout = nil
-        @sv_verbose = false
-        @log_dir = ::File.join('/var/log/', @service_name)
-        @log_flags = '-tt'
-        @log_size = nil
-        @log_num = nil
-        @log_min = nil
-        @log_timeout = nil
-        @log_processor = nil
-        @log_socket = nil
-        @log_prefix = nil
-        @log_config_append = nil
 
         #
         # Backward Compat Hack
@@ -86,197 +93,31 @@ class Chef
         # continue operating.
         #
         unless run_context.nil?
-          service_dir_name = ::File.join(@service_dir, @name)
+          service_dir_name = ::File.join(service_dir, name)
           @service_mirror = Chef::Resource::Service.new(name, run_context)
           @service_mirror.provider(Chef::Provider::Service::Simple)
-          @service_mirror.supports(@supports)
-          @service_mirror.start_command("#{@sv_bin} start #{service_dir_name}")
-          @service_mirror.stop_command("#{@sv_bin} stop #{service_dir_name}")
-          @service_mirror.restart_command("#{@sv_bin} restart #{service_dir_name}")
-          @service_mirror.status_command("#{@sv_bin} status #{service_dir_name}")
+          @service_mirror.supports(supports)
+          @service_mirror.start_command("#{sv_bin} start #{service_dir_name}")
+          @service_mirror.stop_command("#{sv_bin} stop #{service_dir_name}")
+          @service_mirror.restart_command("#{sv_bin} restart #{service_dir_name}")
+          @service_mirror.status_command("#{sv_bin} status #{service_dir_name}")
           @service_mirror.action(:nothing)
           run_context.resource_collection.insert(@service_mirror)
         end
       end
 
-      def sv_bin(arg = nil)
-        set_or_return(:sv_bin, arg, kind_of: [String])
-      end
-
-      def sv_dir(arg = nil)
-        set_or_return(:sv_dir, arg, kind_of: [String, FalseClass])
-      end
-
-      def sv_timeout(arg = nil)
-        set_or_return(:sv_timeout, arg, kind_of: [Integer])
-      end
-
-      def sv_verbose(arg = nil)
-        set_or_return(:sv_verbose, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def service_dir(arg = nil)
-        set_or_return(:service_dir, arg, kind_of: [String])
-      end
-
-      def lsb_init_dir(arg = nil)
-        set_or_return(:lsb_init_dir, arg, kind_of: [String])
-      end
-
-      def control(arg = nil)
-        set_or_return(:control, arg, kind_of: [Array])
-      end
-
-      def options(arg = nil)
-        default_opts = @env.empty? ? @options : @options.merge(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
-
-        merged_opts = arg.respond_to?(:merge) ? default_opts.merge(arg) : default_opts
-
-        set_or_return(
-          :options,
-          merged_opts,
-          kind_of: [Hash],
-          default: default_opts
-        )
-      end
-
-      def env(arg = nil)
-        set_or_return(:env, arg, kind_of: [Hash])
-      end
-
-      ## set log to current instance value if nothing is passed.
-      def log(arg = @log)
-        set_or_return(:log, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def cookbook(arg = nil)
-        set_or_return(:cookbook, arg, kind_of: [String])
-      end
-
-      def finish(arg = nil)
-        set_or_return(:finish, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def check(arg = nil)
-        set_or_return(:check, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def start_down(arg = nil)
-        set_or_return(:start_down, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def delete_downfile(arg = nil)
-        set_or_return(:delete_downfile, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def supervisor_owner(arg = nil)
-        set_or_return(:supervisor_owner, arg, regex: [Chef::Config[:user_valid_regex]])
-      end
-
-      def supervisor_group(arg = nil)
-        set_or_return(:supervisor_group, arg, regex: [Chef::Config[:group_valid_regex]])
-      end
-
-      def owner(arg = nil)
-        set_or_return(:owner, arg, regex: [Chef::Config[:user_valid_regex]])
-      end
-
-      def group(arg = nil)
-        set_or_return(:group, arg, regex: [Chef::Config[:group_valid_regex]])
-      end
-
-      def default_logger(arg = nil)
-        set_or_return(:default_logger, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def restart_on_update(arg = nil)
-        set_or_return(:restart_on_update, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def run_template_name(arg = nil)
-        set_or_return(:run_template_name, arg, kind_of: [String])
-      end
-      alias template_name run_template_name
-
-      def log_template_name(arg = nil)
-        set_or_return(:log_template_name, arg, kind_of: [String])
-      end
-
-      def check_script_template_name(arg = nil)
-        set_or_return(:check_script_template_name, arg, kind_of: [String])
-      end
-
-      def finish_script_template_name(arg = nil)
-        set_or_return(:finish_script_template_name, arg, kind_of: [String])
-      end
-
-      def control_template_names(arg = nil)
-        set_or_return(
-          :control_template_names,
-          arg,
-          kind_of: [Hash],
-          default: set_control_template_names
-        )
-      end
-
-      def set_control_template_names
-        @control.each do |signal|
-          @control_template_names[signal] ||= @service_name
-        end
-        @control_template_names
-      end
-
-      def sv_templates(arg = nil)
-        set_or_return(:sv_templates, arg, kind_of: [TrueClass, FalseClass])
-      end
-
-      def log_dir(arg = nil)
-        set_or_return(:log_dir, arg, kind_of: [String])
-      end
-
-      def log_flags(arg = nil)
-        set_or_return(:log_flags, arg, kind_of: [String])
-      end
-
-      def log_size(arg = nil)
-        set_or_return(:log_size, arg, kind_of: [Integer])
-      end
-
-      def log_num(arg = nil)
-        set_or_return(:log_num, arg, kind_of: [Integer])
-      end
-
-      def log_min(arg = nil)
-        set_or_return(:log_min, arg, kind_of: [Integer])
-      end
-
-      def log_timeout(arg = nil)
-        set_or_return(:log_timeout, arg, kind_of: [Integer])
-      end
-
-      def log_processor(arg = nil)
-        set_or_return(:log_processor, arg, kind_of: [String])
-      end
-
-      def log_socket(arg = nil)
-        set_or_return(:log_socket, arg, kind_of: [String, Hash])
-      end
-
-      def log_prefix(arg = nil)
-        set_or_return(:log_prefix, arg, kind_of: [String])
-      end
-
-      def log_config_append(arg = nil)
-        set_or_return(:log_config_append, arg, kind_of: [String])
-      end
-
-      def runit_attributes_from_node(run_context)
-        if run_context && run_context.node && run_context.node['runit']
-          run_context.node['runit']
-        else
-          {}
-        end
-      end
+      # def options(arg = nil)
+      #   default_opts = @env.empty? ? @options : @options.merge(env_dir: ::File.join(@sv_dir, @service_name, 'env'))
+      #
+      #   merged_opts = arg.respond_to?(:merge) ? default_opts.merge(arg) : default_opts
+      #
+      #   set_or_return(
+      #     :options,
+      #     merged_opts,
+      #     kind_of: [Hash],
+      #     default: default_opts
+      #   )
+      # end
     end
   end
 end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -93,13 +93,14 @@ class Chef
       def after_created
         unless run_context.nil?
           new_resource = self
+          service_dir_name = ::File.join(service_dir, service_name)
           find_resource(:service, new_resource.name) do # creates if it does not exist
             provider Chef::Provider::Service::Simple
             supports new_resource.supports
-            start_command "#{new_resource.sv_bin} start #{new_resource.service_dir_name}"
-            stop_command "#{new_resource.sv_bin} stop #{new_resource.service_dir_name}"
-            restart_command "#{new_resource.sv_bin} restart #{new_resource.service_dir_name}"
-            status_command "#{new_resource.sv_bin} status #{new_resource.service_dir_name}"
+            start_command "#{new_resource.sv_bin} start #{service_dir_name}"
+            stop_command "#{new_resource.sv_bin} stop #{service_dir_name}"
+            restart_command "#{new_resource.sv_bin} restart #{service_dir_name}"
+            status_command "#{new_resource.sv_bin} status #{service_dir_name}"
             action :nothing
           end
         end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -89,6 +89,21 @@ class Chef
       def default_options
         env.empty? ? {} : { env_dir: ::File.join(sv_dir, service_name, 'env') }
       end
+
+      def after_created
+        unless run_context.nil?
+          new_resource = self
+          find_resource(:service, new_resource.name) do # creates if it does not exist
+            provider Chef::Provider::Service::Simple
+            supports new_resource.supports
+            start_command "#{new_resource.sv_bin} start #{new_resource.service_dir_name}"
+            stop_command "#{new_resource.sv_bin} stop #{new_resource.service_dir_name}"
+            restart_command "#{new_resource.sv_bin} restart #{new_resource.service_dir_name}"
+            status_command "#{new_resource.sv_bin} status #{new_resource.service_dir_name}"
+            action :nothing
+          end
+        end
+      end
     end
   end
 end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -76,10 +76,11 @@ class Chef
       alias template_name run_template_name
 
       def set_control_template_names
+        template_names = {}
         control.each do |signal|
-          control_template_names[signal] ||= service_name
+          template_names[signal] ||= service_name
         end
-        control_template_names
+        template_names
       end
 
       # the default legacy options kept for compatibility with the definition

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -3,7 +3,7 @@
 # resource:: runit_service
 #
 # Author:: Joshua Timberman <jtimberman@chef.io>
-# Copyright:: 2011-2019, Chef Software, Inc.
+# Copyright:: 2011-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,30 +74,6 @@ class Chef
       property :log_config_append, String
 
       alias template_name run_template_name
-
-      def initialize(name, run_context = nil)
-        super
-        #
-        # Backward Compat Hack
-        #
-        # This ensures a 'service' resource exists for all 'runit_service' resources.
-        # This should allow all recipes using the previous 'runit_service' definition to
-        # continue operating.
-        #
-        unless run_context.nil?
-          service_dir_name = ::File.join(service_dir, service_name)
-          @service_mirror = Chef::Resource::Service.new(name, run_context)
-          @service_mirror.provider(Chef::Provider::Service::Simple)
-          @service_mirror.supports(supports)
-          @service_mirror.start_command("#{sv_bin} start #{service_dir_name}")
-          @service_mirror.stop_command("#{sv_bin} stop #{service_dir_name}")
-          @service_mirror.restart_command("#{sv_bin} restart #{service_dir_name}")
-          @service_mirror.status_command("#{sv_bin} status #{service_dir_name}")
-          @service_mirror.action(:nothing)
-          run_context.resource_collection.insert(@service_mirror)
-        end
-      end
-
 
       def set_control_template_names
         template_names = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ depends 'yum-epel'
 
 source_url 'https://github.com/chef-cookbooks/runit'
 issues_url 'https://github.com/chef-cookbooks/runit/issues'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 13.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit
 # Recipe:: default
 #
-# Copyright:: 2008-2016, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,7 +61,7 @@ plat_specific_sv_name = case node['platform_family']
                             'runit'
                           end
                         when 'rhel', 'amazon'
-                          if node['platform_version'].to_i >= 7 && !platform?('amazon')
+                          if node['platform_version'].to_i >= 7 && platform_family?('rhel')
                             'runsvdir-start'
                           elsif node['platform_version'].to_i == 2 && platform?('amazon')
                             'runsvdir-start'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ when 'rhel', 'amazon'
 
   # add the necessary repos unless prefer_local_yum is set
   unless node['runit']['prefer_local_yum']
-    include_recipe 'yum-epel' if node['platform_version'].to_i < 7 && !platform?('amazon')
+    include_recipe 'yum-epel' if node['platform_version'].to_i < 7 && platform_family?('rhel')
 
     packagecloud_repo 'imeyer/runit' do
       force_os 'rhel' if platform?('oracle', 'amazon') # ~FC024

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,5 +76,4 @@ service plat_specific_sv_name do
   action [:start, :enable]
   # this might seem crazy, but RHEL 6 is in fact Upstart and the runit service is upstart there
   provider Chef::Provider::Service::Upstart if (platform?('amazon') && node['platform_version'].to_i != 2) || (platform_family?('rhel') && node['platform_version'].to_i == 6)
-  not_if { platform?('debian') && node['platform_version'].to_i < 8 } # there's no init script on debian 7...for reasons
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ when 'rhel', 'amazon'
 
   # add the necessary repos unless prefer_local_yum is set
   unless node['runit']['prefer_local_yum']
-    include_recipe 'yum-epel' if node['platform_version'].to_i < 7
+    include_recipe 'yum-epel' if node['platform_version'].to_i < 7 && !platform?('amazon')
 
     packagecloud_repo 'imeyer/runit' do
       force_os 'rhel' if platform?('oracle', 'amazon') # ~FC024

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -51,7 +51,7 @@ describe 'runit::default' do
     end
 
     it 'adds packagecloud_repo[imeyer/runit]' do
-      is_expected.to add_packagecloud_repo('imeyer/runit')
+      is_expected.to add_packagecloud_repo('imeyer/runit').with(force_os: 'rhel', force_dist: '6', type: 'rpm')
     end
 
     it 'installs the runit package' do
@@ -72,7 +72,7 @@ describe 'runit::default' do
     end
 
     it 'adds packagecloud_repo[imeyer/runit]' do
-      is_expected.to add_packagecloud_repo('imeyer/runit')
+      is_expected.to add_packagecloud_repo('imeyer/runit').with(force_os: 'rhel', force_dist: '7', type: 'rpm')
     end
 
     it 'installs the runit package' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,187 +1,152 @@
 require 'spec_helper'
 
-describe 'runit::default on centos 6' do
-  cached(:centos6_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'centos',
-      version: '6.9'
-    ).converge('runit::default')
+describe 'runit::default' do
+  context 'on centos 6' do
+    platform 'centos', '6'
+
+    it 'includes the yum-epel::default recipe' do
+      is_expected.to include_recipe('yum-epel::default')
+    end
+
+    it 'adds packagecloud_repo[imeyer/runit]' do
+      is_expected.to add_packagecloud_repo('imeyer/runit')
+    end
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runsvdir')
+      is_expected.to start_service('runsvdir')
+    end
   end
 
-  it 'includes the yum-epel::default recipe' do
-    expect(centos6_default).to include_recipe('yum-epel::default')
+  context 'on centos 7' do
+    platform 'centos', '7'
+
+    it 'includes the yum-epel::default recipe' do
+      is_expected.to_not include_recipe('yum-epel::default')
+    end
+
+    it 'adds packagecloud_repo[imeyer/runit]' do
+      is_expected.to add_packagecloud_repo('imeyer/runit')
+    end
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runsvdir-start')
+      is_expected.to start_service('runsvdir-start')
+    end
   end
 
-  it 'adds packagecloud_repo[imeyer/runit]' do
-    expect(centos6_default).to add_packagecloud_repo('imeyer/runit')
+  context 'on Amazon Linux 201X' do
+    platform 'amazon', '2016'
+
+    it 'includes the yum-epel::default recipe' do
+      is_expected.to_not include_recipe('yum-epel::default')
+    end
+
+    it 'adds packagecloud_repo[imeyer/runit]' do
+      is_expected.to add_packagecloud_repo('imeyer/runit')
+    end
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runsvdir')
+      is_expected.to start_service('runsvdir')
+    end
   end
 
-  it 'installs the runit package' do
-    expect(centos6_default).to install_package('runit')
+  context 'on Amazon Linux 2' do
+    platform 'amazon', '2'
+
+    it 'includes the yum-epel::default recipe' do
+      is_expected.to_not include_recipe('yum-epel::default')
+    end
+
+    it 'adds packagecloud_repo[imeyer/runit]' do
+      is_expected.to add_packagecloud_repo('imeyer/runit')
+    end
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runsvdir-start')
+      is_expected.to start_service('runsvdir-start')
+    end
   end
 
-  it 'starts and enabled the correct runit service' do
-    expect(centos6_default).to enable_service('runsvdir')
-    expect(centos6_default).to start_service('runsvdir')
-  end
-end
+  context 'on Ubuntu 14.04' do
+    platform 'ubuntu', '14.04'
 
-describe 'runit::default on centos 7' do
-  cached(:centos7_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'centos',
-      version: '7.4.1708'
-    ).converge('runit::default')
-  end
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
 
-  it 'does not include the yum-epel::default recipe' do
-    expect(centos7_default).to_not include_recipe('yum-epel::default')
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runsvdir')
+      is_expected.to start_service('runsvdir')
+    end
   end
 
-  it 'adds packagecloud_repo[imeyer/runit]' do
-    expect(centos7_default).to add_packagecloud_repo('imeyer/runit')
+  context 'on Ubuntu 16.04' do
+    platform 'ubuntu', '16.04'
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runit')
+      is_expected.to start_service('runit')
+    end
   end
 
-  it 'installs the runit package' do
-    expect(centos7_default).to install_package('runit')
+  context 'on Ubuntu 18.04' do
+    platform 'ubuntu', '18.04'
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit-systemd')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runit')
+      is_expected.to start_service('runit')
+    end
   end
 
-  it 'starts and enabled the correct runit service' do
-    expect(centos7_default).to enable_service('runsvdir-start')
-    expect(centos7_default).to start_service('runsvdir-start')
-  end
-end
+  context 'on Debian 8' do
+    platform 'Debian', '8'
 
-describe 'runit::default on amazon linux' do
-  cached(:amazon_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'amazon',
-      version: '2017.03'
-    ).converge('runit::default')
-  end
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
 
-  it 'does not include the yum-epel::default recipe' do
-    expect(amazon_default).to_not include_recipe('yum-epel::default')
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runit')
+      is_expected.to start_service('runit')
+    end
   end
 
-  it 'adds packagecloud_repo[imeyer/runit]' do
-    expect(amazon_default).to add_packagecloud_repo('imeyer/runit')
-  end
+  context 'on Debian 9' do
+    platform 'debian', '9'
 
-  it 'installs the runit package' do
-    expect(amazon_default).to install_package('runit')
-  end
+    it 'installs the runit package' do
+      is_expected.to install_package('runit-systemd')
+    end
 
-  it 'starts and enabled the correct runit service' do
-    expect(amazon_default).to enable_service('runsvdir')
-    expect(amazon_default).to start_service('runsvdir')
-  end
-end
-
-describe 'runit::default on ubuntu 14.04' do
-  cached(:ubuntu14_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'ubuntu',
-      version: '14.04'
-    ).converge('runit::default')
-  end
-
-  it 'installs the runit package' do
-    expect(ubuntu14_default).to install_package('runit')
-  end
-
-  it 'starts and enabled the correct runit service' do
-    expect(ubuntu14_default).to enable_service('runsvdir')
-    expect(ubuntu14_default).to start_service('runsvdir')
-  end
-end
-
-describe 'runit::default on ubuntu 16.04' do
-  cached(:ubuntu16_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'ubuntu',
-      version: '16.04'
-    ).converge('runit::default')
-  end
-
-  it 'installs the runit package' do
-    expect(ubuntu16_default).to install_package('runit')
-  end
-
-  it 'starts and enabled the correct runit service' do
-    expect(ubuntu16_default).to enable_service('runit')
-    expect(ubuntu16_default).to start_service('runit')
-  end
-end
-
-describe 'runit::default on ubuntu 18.04' do
-  cached(:ubuntu18_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'ubuntu',
-      version: '18.04'
-    ).converge('runit::default')
-  end
-
-  it 'installs the runit-systemd package' do
-    expect(ubuntu18_default).to install_package('runit-systemd')
-  end
-
-  it 'starts and enabled the correct runit service' do
-    expect(ubuntu18_default).to enable_service('runit')
-    expect(ubuntu18_default).to start_service('runit')
-  end
-end
-
-describe 'runit::default on debian 7' do
-  cached(:debian7_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'debian',
-      version: '7.11'
-    ).converge('runit::default')
-  end
-
-  it 'installs the runit package' do
-    expect(debian7_default).to install_package('runit')
-  end
-
-  it 'does not start or enabled the a runit service' do
-    expect(debian7_default).to_not enable_service('runit')
-    expect(debian7_default).to_not start_service('runit')
-  end
-end
-
-describe 'runit::default on debian 8' do
-  cached(:debian8_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'debian',
-      version: '8.9'
-    ).converge('runit::default')
-  end
-
-  it 'installs the runit package' do
-    expect(debian8_default).to install_package('runit')
-  end
-
-  it 'starts and enabled the correct runit service' do
-    expect(debian8_default).to enable_service('runit')
-    expect(debian8_default).to start_service('runit')
-  end
-end
-
-describe 'runit::default on debian 9' do
-  cached(:debian9_default) do
-    ChefSpec::SoloRunner.new(
-      platform: 'debian',
-      version: '9.2'
-    ).converge('runit::default')
-  end
-
-  it 'installs the runit-systemd package' do
-    expect(debian9_default).to install_package('runit-systemd')
-  end
-
-  it 'starts and enabled the correct runit service' do
-    expect(debian9_default).to enable_service('runit')
-    expect(debian9_default).to start_service('runit')
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runit')
+      is_expected.to start_service('runit')
+    end
   end
 end

--- a/test/cookbooks/runit_test/recipes/default.rb
+++ b/test/cookbooks/runit_test/recipes/default.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 include_recipe 'runit::default'

--- a/test/cookbooks/runit_test/recipes/default.rb
+++ b/test/cookbooks/runit_test/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit_test
 # Recipe:: default
 #
-# Copyright:: 2012-2016, Chef Software, Inc.
+# Copyright:: 2012-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit_test
 # Recipe:: service
 #
-# Copyright:: 2012-2016, Chef Software, Inc.
+# Copyright:: 2012-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -246,7 +246,7 @@ end
 # Use a service with all the fixin's to ensure all actions are
 # available and working
 
-actions = (runit_service('plain-defaults').allowed_actions - [:enable, :disable]) + [:disable, :enable]
+actions = (runit_service('plain-defaults').allowed_actions - [:enable, :disable, :mask, :unmask]) + [:disable, :enable]
 
 actions.each do |test_action|
   runit_service 'plain-defaults' do

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -153,13 +153,6 @@ runit_service 'ayahuasca' do
   log_flags '-t'
 end
 
-# Note: this won't update the run script for the above due to
-# http://tickets.chef.io/browse/COOK-2353
-# runit_service 'the other name for yerba-alt' do
-#   service_name 'yerba-alt'
-#   default_logger true
-# end
-
 runit_service 'exist-disabled' do
   action [:create, :disable]
 end

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -158,14 +158,14 @@ runit_service 'exist-disabled' do
   action [:create, :disable]
 end
 
-# unless platform_family?('rhel', 'fedora')
-#   # Create a service that has a package with its own service directory
-#   package 'git-daemon-run'
+unless platform_family?('rhel', 'fedora', 'amazon')
+  # Create a service that has a package with its own service directory
+  package 'git-daemon-run'
 
-#   runit_service 'git-daemon' do
-#     sv_templates false
-#   end
-# end
+  runit_service 'git-daemon' do
+    sv_templates false
+  end
+end
 
 # Despite waiting for runit to create supervise/ok, sometimes services
 # are supervised, but not actually fully started

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -50,12 +50,12 @@ end
 # drop off environment files outside of the runit_service resources
 # so we can test manage_env_dir behavior
 %w(plain-defaults env-files).each do |svc|
-  directory "#{node['runit']['sv_dir']}/#{svc}/env" do
+  directory "/etc/sv/#{svc}/env" do
     recursive true
     action :nothing
   end.run_action(:create)
 
-  file "#{node['runit']['sv_dir']}/#{svc}/env/ZAP_TEST" do
+  file "/etc/sv/#{svc}/env/ZAP_TEST" do
     content '1'
     action :nothing
   end.run_action(:create)

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -186,15 +186,6 @@ file '/tmp/notifier-2' do
   notifies :restart, 'runit_service[plain-defaults]', :immediately
 end
 
-# # Test for COOK-2867
-# link '/etc/init.d/cook-2867' do
-#   to '/usr/bin/sv'
-# end
-
-# runit_service 'cook-2867' do
-#   default_logger true
-# end
-
 # create a service using an alternate sv binary
 runit_service 'alternative-sv-bin' do
   sv_bin '/usr/local/bin/sv'

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -151,6 +151,7 @@ end
 runit_service 'ayahuasca' do
   default_logger true
   log_flags '-t'
+  cookbook 'runit_other_test'
 end
 
 runit_service 'exist-disabled' do


### PR DESCRIPTION
The current resource is broken in Chef 15 because it inherits from Chef's service resource in a way that is entirely dependent on that resources implementation. We refactored service in Chef 15 and runit_service needs to be updated to decouple it from the underlying service resource.