### PR TITLE
Add a new use_init_script_sv_link property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=default-amazonlinux CHEF_VERSION=13.0.118
-  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=13.0.118
-  - INSTANCE=default-ubuntu-1604 CHEF_VERSION=13.0.118
-  - INSTANCE=default-ubuntu-1804 CHEF_VERSION=13.0.118
-  - INSTANCE=default-debian-8 CHEF_VERSION=13.0.118
-  - INSTANCE=default-debian-9 CHEF_VERSION=13.0.118
-  - INSTANCE=default-centos-6 CHEF_VERSION=13.0.118
-  - INSTANCE=default-centos-7 CHEF_VERSION=13.0.118
+  - INSTANCE=default-amazonlinux CHEF_VERSION=14.0.202
+  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=14.0.202
+  - INSTANCE=default-ubuntu-1604 CHEF_VERSION=14.0.202
+  - INSTANCE=default-ubuntu-1804 CHEF_VERSION=14.0.202
+  - INSTANCE=default-debian-8 CHEF_VERSION=14.0.202
+  - INSTANCE=default-debian-9 CHEF_VERSION=14.0.202
+  - INSTANCE=default-centos-6 CHEF_VERSION=14.0.202
+  - INSTANCE=default-centos-7 CHEF_VERSION=14.0.202
   - INSTANCE=default-amazonlinux
   - INSTANCE=default-amazonlinux-2
   - INSTANCE=default-ubuntu-1404
@@ -41,7 +41,7 @@ before_script:
   - cookstyle --version
   - foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
+script: CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   - cookstyle --version
   - foodcritic --version
 
-script: CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
+script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-dist: xenial
-
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-current-xenial
     packages:
       - chefdk
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ services: docker
 env:
   matrix:
   - INSTANCE=default-amazonlinux CHEF_VERSION=14.0.202
-  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=14.0.202
   - INSTANCE=default-ubuntu-1604 CHEF_VERSION=14.0.202
   - INSTANCE=default-ubuntu-1804 CHEF_VERSION=14.0.202
   - INSTANCE=default-debian-8 CHEF_VERSION=14.0.202
@@ -26,7 +25,6 @@ env:
   - INSTANCE=default-centos-7 CHEF_VERSION=14.0.202
   - INSTANCE=default-amazonlinux
   - INSTANCE=default-amazonlinux-2
-  - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
   - INSTANCE=default-ubuntu-1804
   - INSTANCE=default-debian-8

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -9,6 +9,7 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -39,6 +39,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
+- name: debian-10
+  driver:
+    image: dokken/debian-10
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
 - name: centos-6
   driver:
     image: dokken/centos-6
@@ -48,13 +55,6 @@ platforms:
   driver:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
-
-- name: ubuntu-14.04
-  driver:
-    image: dokken/ubuntu-14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
 
 - name: ubuntu-16.04
   driver:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,7 +19,6 @@ platforms:
   - name: debian-9
   - name: oracle-6
   - name: oracle-7
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04
 

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -213,7 +213,7 @@ class Chef
           end
 
           new_resource.control.map do |signal|
-            template ::File.join(sv_dir_name, 'control', 'signal') do
+            template ::File.join(sv_dir_name, 'control', signal) do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode '0755'

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -225,7 +225,7 @@ class Chef
           end
 
           # lsb_init
-          if node['platform'] == 'debian' || node['platform'] == 'ubuntu'
+          if platform?('debian','ubuntu') && !new_resource.use_init_script_sv_link
             ruby_block "unlink #{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}" do
               block { ::File.unlink(::File.join(new_resource.lsb_init_dir, new_resource.service_name).to_s) }
               only_if { ::File.symlink?(::File.join(new_resource.lsb_init_dir, new_resource.service_name).to_s) }

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -73,6 +73,10 @@ class Chef
       property :log_prefix, String
       property :log_config_append, String
 
+      # Use a link to sv instead of a full blown init script calling runit.
+      # This was added for omnibus projects and probably shouldn't be used elsewhere
+      property :use_init_script_sv_link, [TrueClass, FalseClass], default: false
+
       alias template_name run_template_name
 
       def set_control_template_names


### PR DESCRIPTION
I'm not adding this to the readme as this is something that should
*really* only be used by Chef internally. Basically our issue is that
that runit cookbook now drops an init script on Ubntu hosts instead of a
link to sv. The link to sv combined with our control file would allow us
to properly signal services with their full path. When you use the init
script that gets laid down you only get the short name like 'postgresl'
which won't help when you're in an omnibus package.1

Signed-off-by: Tim Smith <tsmith@chef.io>