### PR TITLE
Fix options property not taking on the legacy default valuue

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,8 +15,8 @@ platforms:
       box: mvbcoding/awslinux
   - name: centos-6
   - name: centos-7
-  - name: debian-8
   - name: debian-9
+  - name: debian-10
   - name: oracle-6
   - name: oracle-7
   - name: ubuntu-16.04

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -225,7 +225,7 @@ class Chef
           end
 
           # lsb_init
-          if platform?('debian','ubuntu') && !new_resource.use_init_script_sv_link
+          if platform?('debian', 'ubuntu') && !new_resource.use_init_script_sv_link
             ruby_block "unlink #{::File.join(new_resource.lsb_init_dir, new_resource.service_name)}" do
               block { ::File.unlink(::File.join(new_resource.lsb_init_dir, new_resource.service_name).to_s) }
               only_if { ::File.symlink?(::File.join(new_resource.lsb_init_dir, new_resource.service_name).to_s) }

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -89,7 +89,7 @@ class Chef
 
       # the default legacy options kept for compatibility with the definition
       #
-      # @return [Hash] if env is the default empty hash then return env_dir valuue. Otherwise return an empty hash
+      # @return [Hash] if env is the default empty hash then return env_dir value. Otherwise return an empty hash
       def default_options
         env.empty? ? { env_dir: ::File.join(sv_dir, service_name, 'env') } : {}
       end

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -89,9 +89,9 @@ class Chef
 
       # the default legacy options kept for compatibility with the definition
       #
-      # @return [Hash] an empty hash if env property is set. Otherwise it's env_dir
+      # @return [Hash] if env is the default empty hash then return env_dir valuue. Otherwise return an empty hash
       def default_options
-        env.empty? ? {} : { env_dir: ::File.join(sv_dir, service_name, 'env') }
+        env.empty? ? { env_dir: ::File.join(sv_dir, service_name, 'env') } : {}
       end
 
       def after_created

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,9 +43,9 @@ when 'debian'
                'runit'
              end
 
-  package pkg_name do
+  package pkg_name do # ~FC009
     action :install
-    response_file 'runit.seed'
+    response_file 'runit.seed' 
   end
 else
   raise 'The cookbook only supports Debian/RHEL based Linux distributions. If you believe further platform support is possible please open a pull request.'


### PR DESCRIPTION
The logic here was backwards. If env property is an empty hash then
that's an unset default and we want to use env_dir. Otherwise return {}

Signed-off-by: Tim Smith <tsmith@chef.io>