### PR TITLE
Make call to shell_out compatible with Ruby 3

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -121,7 +121,7 @@ module RunitCookbook
     def safe_sv_shellout(command, options = {})
       begin
         Chef::Log.debug("Attempting to run runit command: #{new_resource.sv_bin} #{command}")
-        cmd = shell_out("#{new_resource.sv_bin} #{command}", options)
+        cmd = shell_out("#{new_resource.sv_bin} #{command}", **options)
       rescue Errno::ENOENT
         if binary_exists?
           raise # Some other cause


### PR DESCRIPTION
### Description

In previous versions of Ruby, calling `shell_out("cmd", { blah : "blah" })` would be interpreted correctly [here](https://github.com/chef/mixlib-shellout/blob/e2ec87f6f5933e5e5bc75a9fe08a8c8c73e55b72/lib/mixlib/shellout/helper.rb#L38) as `args = "cmd"` and `options = { blah : "blah" }`.

However because this can be ambiguous to interpret, Ruby would give the warning:
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

As of Ruby 3, `shell_out("cmd", { blah : "blah" })` will be interpreted as `args = ["cmd", { blah : "blah" }]` and `options = {}`.

This can be fixed by passing in the `options` parameter with a double splat (**) in front of it to explicitly convert the hash into a keyword argument.

### Issues Resolved

No open issues.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>