### PR TITLE
Install runit on ubuntu22.04 instead of runit-systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # runit Cookbook CHANGELOG
 
 This file is used to list changes made in each version of the runit cookbook.
-## 5.1.7-bugsnag1 (2023-02-21)
+## 5.2.0 (2023-02-21)
 
 - Add ubuntu 22.04 support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # runit Cookbook CHANGELOG
 
 This file is used to list changes made in each version of the runit cookbook.
+## 5.1.7-bugsnag1 (2023-02-21)
+
+- Add ubuntu 22.04 support
 
 ## 5.1.7 (2022-04-25)
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -63,3 +63,17 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+
+- name: ubuntu-20.04
+  driver:
+    image: dokken/ubuntu-20.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: ubuntu-22.04
+  driver:
+    image: dokken/ubuntu-22.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,6 +22,8 @@ platforms:
   - name: oracle-7
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
+  - name: ubuntu-22.04
 
 suites:
 - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'runit'
 maintainer 'SmartBear Software, Inc.'
 license 'Apache-2.0'
 description 'Installs runit and provides runit_service resource'
-version '5.1.7-bugsnag1'
+version '5.2.0'
 
 %w(ubuntu debian centos redhat amazon scientific oracle enterpriseenterprise zlinux).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,8 @@
 name 'runit'
-maintainer 'Chef Software, Inc.'
-maintainer_email 'cookbooks@chef.io'
+maintainer 'SmartBear Software, Inc.'
 license 'Apache-2.0'
 description 'Installs runit and provides runit_service resource'
-version '5.1.7'
+version '5.1.7-bugsnag1'
 
 %w(ubuntu debian centos redhat amazon scientific oracle enterpriseenterprise zlinux).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,7 +37,7 @@ when 'debian'
   # what is necessary for running runit as pid 1, which we don't care about.
   pv = node['platform_version']
   pkg_name = if (platform?('debian') && pv.to_i >= 9) || \
-                (platform?('ubuntu') && Gem::Version.new(pv) >= Gem::Version.new('17.10'))
+                (platform?('ubuntu') && Gem::Version.new(pv) >= Gem::Version.new('17.10') && Gem::Version.new(pv) < Gem::Version.new('22.04'))
                'runit-systemd'
              else
                'runit'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -111,6 +111,32 @@ describe 'runit::default' do
     end
   end
 
+  context 'on Ubuntu 20.04' do
+    platform 'ubuntu', '20.04'
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit-systemd')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runit')
+      is_expected.to start_service('runit')
+    end
+  end
+
+  context 'on Ubuntu 22.04' do
+    platform 'ubuntu', '22.04'
+
+    it 'installs the runit package' do
+      is_expected.to install_package('runit')
+    end
+
+    it 'starts and enabled the correct runit service' do
+      is_expected.to enable_service('runit')
+      is_expected.to start_service('runit')
+    end
+  end
+
   context 'on Debian 9' do
     platform 'Debian', '9'
 

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+apt_update 'update'
 
 include_recipe 'runit::default'
 

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,5 +1,5 @@
 if (os[:name] == 'debian' && os[:release].to_i >= 9) || \
-   (os[:name] == 'ubuntu' && Gem::Version.new(os[:release]) >= Gem::Version.new('17.10'))
+   (os[:name] == 'ubuntu' && Gem::Version.new(os[:release]) >= Gem::Version.new('17.10') && Gem::Version.new(os[:release]) < Gem::Version.new('22.04'))
   describe package('runit-systemd') do
     it { should be_installed }
   end

--- a/test/integration/service/all_distros_specs.rb
+++ b/test/integration/service/all_distros_specs.rb
@@ -39,7 +39,7 @@ control 'creates a service that uses the default svlog' do
   end
 
   describe command('file /var/log/default-svlog/*.s') do
-    its(:stdout) { should contain('gzip compressed data') }
+    its(:stdout) { should match(/gzip compressed data/) }
   end
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
Get rid of `runit-systemd` for ubuntu 22.04 since it has migrated to runit and runit-run
With this change, ubuntu 22.04 now converaged successfully. Default tests passed
Add ubuntu 20.04 in the support list as well. Default test passed.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>