### PR TITLE
CHEF-30613 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,6 @@ For redhat derivatives:
 - Author:: Sean OMeara [sean@sean.io](mailto:sean@sean.io)
 
 ```text
-Copyright:: 2008-2019, Chef Software, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -388,3 +387,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit
 # Attribute:: File:: sv_bin
 #
-# Copyright:: 2008-2019, Chef Software Inc.
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Joshua Timberman <joshua@chef.io>
 # Author:: Sean OMeara <sean@sean.io>
-# Copyright:: 2008-2019, Chef Software, Inc. <legal@chef.io>
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_runit_service.rb
+++ b/libraries/provider_runit_service.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Joshua Timberman <jtimberman@chef.io>
 # Author:: Sean OMeara <sean@sean.io>
-# Copyright:: 2011-2019, Chef Software Inc.
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/resource_runit_service.rb
+++ b/libraries/resource_runit_service.rb
@@ -3,7 +3,7 @@
 # resource:: runit_service
 #
 # Author:: Joshua Timberman <jtimberman@chef.io>
-# Copyright:: 2011-2019, Chef Software Inc.
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit
 # Recipe:: default
 #
-# Copyright:: 2008-2019, Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/runit_test/recipes/default.rb
+++ b/test/cookbooks/runit_test/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit_test
 # Recipe:: default
 #
-# Copyright:: 2012-2019, Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/runit_test/recipes/service.rb
+++ b/test/cookbooks/runit_test/recipes/service.rb
@@ -2,7 +2,7 @@
 # Cookbook:: runit_test
 # Recipe:: service
 #
-# Copyright:: 2012-2019, Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2023 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2012-2023 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:377` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
